### PR TITLE
[feat]: 맵 에셋 로더 외부 접근 지원 및 인게임 매니저 사이클 개선, PlayerRaceData 셋업 수정

### DIFF
--- a/Assets/00_WorkSpace/YSJ/Scripts/Player/PlayerRaceData.cs
+++ b/Assets/00_WorkSpace/YSJ/Scripts/Player/PlayerRaceData.cs
@@ -411,7 +411,7 @@ public class PlayerRaceData : MonoBehaviour, IPunInstantiateMagicCallback
         // 플레이어의 커스텀 프롬퍼티 생성 시점 > 매칭이 되었을 때
         // 룸데이터는 그 이전에 되어 있어야된다.
         var pm = PlayerManager.Instance;
-        pm.SetPlayerCPRaceLoaded(true);
+        pm.SetPlayerCPRaceLoaded(_isSetups);
     }
 
     // 네트워크

--- a/Assets/00_WorkSpace/YTW/Manager/Manager/MapCycleManager.cs
+++ b/Assets/00_WorkSpace/YTW/Manager/Manager/MapCycleManager.cs
@@ -1,3 +1,4 @@
+ï»¿using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -10,11 +11,13 @@ namespace YTW
     {
         public static MapCycleManager Instance { get; private set; }
 
-        [Header("·ÎµåÇÒ ¸Ê ¿¡¼Â ÁÖ¼Ò ¸ñ·Ï")]
+        [Header("ë¡œë“œí•  ë§µ ì—ì…‹ ì£¼ì†Œ ëª©ë¡")]
         [SerializeField] private string[] _mapAddresses;
 
-        // ÇöÀç ¸ÊÀ» ·ÎµåÇÏ°í ÀÖ´Â MapAssetLoaderÀÇ GameObject
+        // í˜„ì¬ ë§µì„ ë¡œë“œí•˜ê³  ìˆëŠ” MapAssetLoaderì˜ GameObject
         private GameObject _currentMapLoaderObject;
+
+        public Action<GameObject> OnLoadRandomMap;
 
         private void Awake()
         {
@@ -30,15 +33,15 @@ namespace YTW
 
         void Start()
         {
-            // ¾ÀÀÌ ½ÃÀÛµÇ¸é ¹Ù·Î Ã¹ ·£´ı ¸Ê ·Îµå
+            // ì”¬ì´ ì‹œì‘ë˜ë©´ ë°”ë¡œ ì²« ëœë¤ ë§µ ë¡œë“œ
             LoadRandomMap();
         }
 
         public void LoadRandomMap()
         {
-            // 1. ±âÁ¸¿¡ ·ÎµåµÈ ¸ÊÀÌ ÀÖ´Ù¸é ÆÄ±«
-            //    _currentMapLoaderObject¸¦ ÆÄ±«ÇÏ¸é, ±× ÀÚ½ÄÀÎ ¸Ê ÀÎ½ºÅÏ½º¿Í
-            //    ÄÄÆ÷³ÍÆ®ÀÎ MapAssetLoaderÀÇ OnDestroy()°¡ ÀÚµ¿À¸·Î È£ÃâµÇ¾î ¸ğµç Á¤¸®¸¦ ¼öÇà
+            // 1. ê¸°ì¡´ì— ë¡œë“œëœ ë§µì´ ìˆë‹¤ë©´ íŒŒê´´
+            //    _currentMapLoaderObjectë¥¼ íŒŒê´´í•˜ë©´, ê·¸ ìì‹ì¸ ë§µ ì¸ìŠ¤í„´ìŠ¤ì™€
+            //    ì»´í¬ë„ŒíŠ¸ì¸ MapAssetLoaderì˜ OnDestroy()ê°€ ìë™ìœ¼ë¡œ í˜¸ì¶œë˜ì–´ ëª¨ë“  ì •ë¦¬ë¥¼ ìˆ˜í–‰
             if (_currentMapLoaderObject != null)
             {
                 Destroy(_currentMapLoaderObject);
@@ -46,21 +49,22 @@ namespace YTW
 
             if (_mapAddresses == null || _mapAddresses.Length == 0)
             {
-                Debug.LogError("[MapCycleManager] ·ÎµåÇÒ ¸Ê ÁÖ¼Ò ¸ñ·ÏÀÌ ºñ¾îÀÖ½À´Ï´Ù.");
+                Debug.LogError("[MapCycleManager] ë¡œë“œí•  ë§µ ì£¼ì†Œ ëª©ë¡ì´ ë¹„ì–´ìˆìŠµë‹ˆë‹¤.");
                 return;
             }
 
-            // 2. ¸Ê ÁÖ¼Ò ¸ñ·Ï¿¡¼­ ·£´ıÀ¸·Î ÇÏ³ª ¼±ÅÃ
-            int randomIndex = Random.Range(0, _mapAddresses.Length);
+            // 2. ë§µ ì£¼ì†Œ ëª©ë¡ì—ì„œ ëœë¤ìœ¼ë¡œ í•˜ë‚˜ ì„ íƒ
+            int randomIndex = UnityEngine.Random.Range(0, _mapAddresses.Length);
             string randomMapAddress = _mapAddresses[randomIndex];
-            Debug.Log($"[MapCycleManager] ´ÙÀ½ ¸Ê ·Îµå ½Ãµµ: {randomMapAddress}");
+            Debug.Log($"[MapCycleManager] ë‹¤ìŒ ë§µ ë¡œë“œ ì‹œë„: {randomMapAddress}");
 
-            // 3. »õ·Î¿î MapAssetLoader¸¦ ´ãÀ» ºó GameObject »ı¼º
+            // 3. ìƒˆë¡œìš´ MapAssetLoaderë¥¼ ë‹´ì„ ë¹ˆ GameObject ìƒì„±
             _currentMapLoaderObject = new GameObject("MapLoader");
 
-            // 4. MapAssetLoader ÄÄÆ÷³ÍÆ® Ãß°¡ ¹× ¼±ÅÃµÈ ÁÖ¼Ò·Î ·Îµå ½ÃÀÛ
+            // 4. MapAssetLoader ì»´í¬ë„ŒíŠ¸ ì¶”ê°€ ë° ì„ íƒëœ ì£¼ì†Œë¡œ ë¡œë“œ ì‹œì‘
             var mapLoader = _currentMapLoaderObject.AddComponent<MapAssetLoader>();
-            _ = mapLoader.InitializeAndLoad(randomMapAddress); // _= : ºñµ¿±â ÇÔ¼ö¸¦ È£ÃâÇÏµÇ, ³¡³¯ ¶§±îÁö ±â´Ù¸®Áö ¾ÊÀ½
+            _ = mapLoader.InitializeAndLoad(randomMapAddress); // _= : ë¹„ë™ê¸° í•¨ìˆ˜ë¥¼ í˜¸ì¶œí•˜ë˜, ëë‚  ë•Œê¹Œì§€ ê¸°ë‹¤ë¦¬ì§€ ì•ŠìŒ
+            OnLoadRandomMap?.Invoke(_currentMapLoaderObject);
         }
     }
 }


### PR DESCRIPTION
## 🧩 개요
- 맵 에셋 로더의 정보를 외부에서 받아볼 수 있도록 기능 추가  
- 인게임 매니저에서 맵 로드 후 → 유니모 카드 배정 → 레이싱 시작으로 이어지는 사이클 구현  
- `PlayerRaceData` 셋업 로직 수정 및 안정화  
- dev 브랜치 병합  

---

## 📁 변경 사항 체크리스트
- [x] C# 스크립트 추가/수정 (`MapAssetLoader`, `InGameManager`, `PlayerRaceData`)  
- [ ] 프리팹 변경  
- [ ] 씬(.unity) 파일 변경  
- [ ] 애니메이션/사운드 리소스 변경  
- [ ] ScriptableObject 변경  
- [x] 기타 리소스 또는 설정 변경 (매니저 사이클 로직 보완)  

---

## ✅ 확인 사항
- [x] Unity 에디터에서 정상 동작 확인  
- [x] 맵 로드 → 카드 배정 → 레이싱 시작 사이클 정상 실행 확인  
- [x] PlayerRaceData 셋업 정상 반영  
- [ ] 변경된 파일이 Git LFS 대상인지 확인 (필요 시)  
- [x] 최신 dev 브랜치와 병합 완료  

---

## 🧪 테스트 내역
- [x] 맵 에셋 로더 외부 접근 정상 동작 확인  
- [x] 인게임 매니저 사이클 테스트 (로드 → 배정 → 레이싱 시작)  
- [x] PlayerRaceData 셋업 로직 검증 완료  
- [ ] 멀티플레이 환경에서 추가 테스트 필요  
