### PR TITLE
[feat]상점 구성 변경(버튼에서 스크롤로), 상점에서 구매시 즉시 비활성화 기능 추가,상점에서 구매했을 때 잔액이 부족하면 비활성화 안되게 변경, 상점도 마이룸의 소지 여부를 파악해서 비활성화 되게 변경

### DIFF
--- a/Assets/00_WorkSpace/MSG/Scripts/Out Game UI/BuyButtonBehaviour.cs
+++ b/Assets/00_WorkSpace/MSG/Scripts/Out Game UI/BuyButtonBehaviour.cs
@@ -58,6 +58,9 @@ namespace MSG
 
         public void RefreshItemState(int currentLevel)
         {
+            // 1. Firebase에서 받은 currentLevel 값을 멤버 변수에 즉시 저장합니다.
+            this._currentLevel = currentLevel;
+
             if (itemType == ItemType.Kart)
             {
                 PatchService.Instance.GetCostOfKart(
@@ -88,17 +91,15 @@ namespace MSG
 
         private void UpdateUI()
         {
-            _buyButtonText.text = "획득";
-            _priceText.text = _itemCost.ToString();
-
-            // 이미 아이템을 소유하고 있는지 여부에 따라 버튼 상태를 변경
-            // _currentLevel은 InventorySnapshot에서 가져온 레벨입니다.
+            // _currentLevel 값이 이제 올바르게 설정되었으므로,
+            // 이 값을 사용하여 UI 상태를 결정합니다.
             if (_currentLevel > 0)
             {
                 // 이미 소유한 아이템
                 _buyButton.interactable = false;
                 _buyButtonText.text = "보유 중";
                 _priceText.text = ""; // 가격 텍스트 숨기기
+                _currencyImage.enabled = false; // 화폐 이미지 숨기기
             }
             else
             {
@@ -106,6 +107,13 @@ namespace MSG
                 _buyButton.interactable = true;
                 _buyButtonText.text = "획득";
                 _priceText.text = _itemCost.ToString();
+                _currencyImage.enabled = true; // 화폐 이미지 보이기
+
+                // 화폐 아이콘 설정
+                if (_moneyType != MoneyType.None)
+                {
+                    _currencyImage.sprite = (_moneyType == MoneyType.Gold) ? _gameMoneySprite : _cashSprite;
+                }
             }
 
             // 예외 처리: 만약 아이템의 가격이 0이라면 구매 불가능
@@ -116,36 +124,40 @@ namespace MSG
             }
         }
 
-        public void ProcessPurchase(int itemId, BuyButtonBehaviour.ItemType itemType, int cost, MoneyType moneyType)
-        {
-
-        }
-
         public void OnClickBuyButton()
         {
-            _buyButton.interactable = false;
             // 이미 아이템을 소유하고 있다면 구매를 시도하지 않고 바로 종료
             if (_currentLevel > 0)
             {
                 Debug.LogWarning("이미 소유한 아이템입니다.");
+                _buyButton.interactable = false; // 혹시 모르니 비활성화 상태 유지
                 return;
             }
+
+            // 구매 시도를 시작할 때 버튼을 비활성화하여 중복 클릭을 막습니다.
+            _buyButton.interactable = false;
 
             string uid = FirebaseManager.Instance?.Auth?.CurrentUser?.UserId;
             if (string.IsNullOrEmpty(uid))
             {
                 Debug.LogError("[ProcessPurchase] 사용자 UID가 유효하지 않습니다.");
+                // 사용자 인증 오류 시 버튼을 다시 활성화
+                _buyButton.interactable = true;
                 return;
             }
 
             // 아이템 구매 트랜잭션 시작
-            TrySpendTransaction(_moneyType,
+            TrySpendTransaction(
+                _moneyType,
                 _itemCost,
                 onDone =>
                 {
-                    if (!onDone)
+                    // 트랜잭션이 완료되면 콜백이 호출됩니다.
+                    if (!onDone) // 잔액 부족 등으로 구매 실패
                     {
                         Debug.LogError("잔액이 부족하거나, 불러오기에 실패 했습니다.");
+                        // 구매 실패 시 버튼을 다시 활성화합니다.
+                        _buyButton.interactable = true;
                         return;
                     }
 
@@ -167,32 +179,6 @@ namespace MSG
                         err => Debug.LogWarning($"{err} 구매 갱신 오류"));
                 });
         }
-
-        // DatabaseManager.Instance.IncrementToLongOnMainWithTransaction(
-        //     moneyPath,
-        //     -_itemCost,
-        //     (long newBalance) =>
-        //     {
-        //         // 트랜잭션이 성공했습니다! 아이템을 지급합니다.
-        //         // 성공 콜백이 호출되었다는 것은 잔액이 충분했다는 의미입니다.
-        //         SetItemInventory(_itemId, itemType, uid);
-        //         Debug.Log($"구매 성공! 새로운 잔액: {newBalance}");
-        //     },
-        //     (error) =>
-        //     {
-        //         // 트랜잭션이 실패했습니다. 여기서 잔액 부족을 처리합니다.
-        //         // Firebase의 권한 거부(permission_denied) 에러가 잔액 부족을 의미할 수 있습니다.
-        //         if (error.Contains("permission_denied"))
-        //         {
-        //             Debug.LogWarning("[ProcessPurchase] 잔액이 부족하여 구매에 실패했습니다.");
-        //         }
-        //         else
-        //         {
-        //             Debug.LogError($"[ProcessPurchase] 코인 거래 실패: {error}");
-        //         }
-        //     }
-        // );
-
 
         // 아이템 인벤토리를 업데이트하는 헬퍼 메서드
         private void SetItemInventory(int itemId, BuyButtonBehaviour.ItemType itemType, string uid)
@@ -234,7 +220,6 @@ namespace MSG
             {
                 MoneyType.Gold => DBRoutes.Gold(CurrentUid),
                 MoneyType.BlueHoneyGem => DBRoutes.BlueHoneyGem(CurrentUid),
-                //MoneyType.Money3 => DBRoutes.Money3(CurrentUid),
                 _ => null
             };
 

--- a/Assets/00_WorkSpace/MSG/Scripts/Out Game UI/BuyButtonBehaviour.cs
+++ b/Assets/00_WorkSpace/MSG/Scripts/Out Game UI/BuyButtonBehaviour.cs
@@ -7,19 +7,23 @@ using UnityEngine.UI;
 
 namespace MSG
 {
-    // SO에 Price가 사라짐으로써 사용되지 않습니다
     public class BuyButtonBehaviour : MonoBehaviour
     {
 
         public enum ItemType { Kart, Unimo }
         [SerializeField] private ItemType itemType;
-        private int _itemId; // private 필드로 선언
+        private int _itemId;
 
         [SerializeField] private TMP_Text _itemName;
         [SerializeField] private Image _itemIcon;
+        [SerializeField] private Image _currencyImage;
         [SerializeField] private TMP_Text _priceText;
         [SerializeField] private TMP_Text _buyButtonText;
         [SerializeField] private Button _buyButton;
+
+        // 인스펙터에 화폐 스프라이트를 참조하도록 설정합니다.
+        [SerializeField] private Sprite _gameMoneySprite;
+        [SerializeField] private Sprite _cashSprite;
 
         private int _itemCost;
         private MoneyType _moneyType;
@@ -27,11 +31,12 @@ namespace MSG
         public Button Button => _buyButton;
         private string CurrentUid => FirebaseManager.Instance?.Auth?.CurrentUser?.UserId;
 
-        public void SetupButton(string name, Sprite sprite, string priceString)
+        public void SetupButton(string name, Sprite itemSprite, string price, Sprite currencyType)
         {
             _itemName.text = name;
-            _itemIcon.sprite = sprite;
-            _priceText.text = priceString;
+            _itemIcon.sprite = itemSprite;
+            _priceText.text = price;
+            _currencyImage.sprite = currencyType;
         }
 
         private void Start()
@@ -83,25 +88,31 @@ namespace MSG
 
         private void UpdateUI()
         {
-            if (itemType == ItemType.Kart)
+            _buyButtonText.text = "획득";
+            _priceText.text = _itemCost.ToString();
+
+            // 이미 아이템을 소유하고 있는지 여부에 따라 버튼 상태를 변경
+            // _currentLevel은 InventorySnapshot에서 가져온 레벨입니다.
+            if (_currentLevel > 0)
             {
-                _buyButtonText.text = _currentLevel > 0 ? "강화" : "획득";
+                // 이미 소유한 아이템
+                _buyButton.interactable = false;
+                _buyButtonText.text = "보유 중";
+                _priceText.text = ""; // 가격 텍스트 숨기기
             }
             else
             {
-                _buyButtonText.text = _currentLevel > 0 ? "보유 중" : "획득";
+                // 아직 소유하지 않은 아이템
+                _buyButton.interactable = true;
+                _buyButtonText.text = "획득";
+                _priceText.text = _itemCost.ToString();
             }
 
+            // 예외 처리: 만약 아이템의 가격이 0이라면 구매 불가능
             if (_itemCost <= 0)
             {
                 _buyButton.interactable = false;
-                _priceText.text = (itemType == ItemType.Kart) ? "최대 레벨" : "보유 중";
-            }
-            else
-            {
-                _buyButton.interactable = true;
-                string moneySuffix = _moneyType == MoneyType.BlueHoneyGem ? "C" : "G";
-                _priceText.text = $"{_itemCost} {moneySuffix}";
+                _priceText.text = "판매 불가";
             }
         }
 
@@ -112,16 +123,22 @@ namespace MSG
 
         public void OnClickBuyButton()
         {
-            string uid = FirebaseManager.Instance?.Auth?.CurrentUser?.UserId;
+            _buyButton.interactable = false;
+            // 이미 아이템을 소유하고 있다면 구매를 시도하지 않고 바로 종료
+            if (_currentLevel > 0)
+            {
+                Debug.LogWarning("이미 소유한 아이템입니다.");
+                return;
+            }
 
+            string uid = FirebaseManager.Instance?.Auth?.CurrentUser?.UserId;
             if (string.IsNullOrEmpty(uid))
             {
                 Debug.LogError("[ProcessPurchase] 사용자 UID가 유효하지 않습니다.");
                 return;
             }
 
-            string moneyPath = GetMoneyPath(_moneyType, uid);
-
+            // 아이템 구매 트랜잭션 시작
             TrySpendTransaction(_moneyType,
                 _itemCost,
                 onDone =>
@@ -131,130 +148,133 @@ namespace MSG
                         Debug.LogError("잔액이 부족하거나, 불러오기에 실패 했습니다.");
                         return;
                     }
+
+                    // 구매 성공: 아이템을 인벤토리에 추가 (레벨 1로 설정)
+                    string inventoryPath;
                     if (itemType == ItemType.Unimo)
                     {
-                        DatabaseManager.Instance.SetOnMain(DBRoutes.UnimoInventory(uid, _itemId),
-                            1,
-                            () => Debug.Log("구매 완료"),
-                        err => Debug.LogWarning($"{err} 구매 갱신 오류"));
+                        inventoryPath = DBRoutes.UnimoInventory(uid, _itemId);
                     }
                     else
                     {
-                        DatabaseManager.Instance.SetOnMain(DBRoutes.KartInventory(uid, _itemId),
-                                        1,
-                                        () => Debug.Log("구매 완료"),
-                            err => Debug.LogWarning($"{err} 구매 갱신 오류"));
+                        inventoryPath = DBRoutes.KartInventory(uid, _itemId);
                     }
+
+                    DatabaseManager.Instance.SetOnMain(
+                        inventoryPath,
+                        1, // 획득이므로 무조건 레벨 1로 설정
+                        () => Debug.Log("구매 완료"),
+                        err => Debug.LogWarning($"{err} 구매 갱신 오류"));
                 });
         }
 
-    // DatabaseManager.Instance.IncrementToLongOnMainWithTransaction(
-    //     moneyPath,
-    //     -_itemCost,
-    //     (long newBalance) =>
-    //     {
-    //         // 트랜잭션이 성공했습니다! 아이템을 지급합니다.
-    //         // 성공 콜백이 호출되었다는 것은 잔액이 충분했다는 의미입니다.
-    //         SetItemInventory(_itemId, itemType, uid);
-    //         Debug.Log($"구매 성공! 새로운 잔액: {newBalance}");
-    //     },
-    //     (error) =>
-    //     {
-    //         // 트랜잭션이 실패했습니다. 여기서 잔액 부족을 처리합니다.
-    //         // Firebase의 권한 거부(permission_denied) 에러가 잔액 부족을 의미할 수 있습니다.
-    //         if (error.Contains("permission_denied"))
-    //         {
-    //             Debug.LogWarning("[ProcessPurchase] 잔액이 부족하여 구매에 실패했습니다.");
-    //         }
-    //         else
-    //         {
-    //             Debug.LogError($"[ProcessPurchase] 코인 거래 실패: {error}");
-    //         }
-    //     }
-    // );
+        // DatabaseManager.Instance.IncrementToLongOnMainWithTransaction(
+        //     moneyPath,
+        //     -_itemCost,
+        //     (long newBalance) =>
+        //     {
+        //         // 트랜잭션이 성공했습니다! 아이템을 지급합니다.
+        //         // 성공 콜백이 호출되었다는 것은 잔액이 충분했다는 의미입니다.
+        //         SetItemInventory(_itemId, itemType, uid);
+        //         Debug.Log($"구매 성공! 새로운 잔액: {newBalance}");
+        //     },
+        //     (error) =>
+        //     {
+        //         // 트랜잭션이 실패했습니다. 여기서 잔액 부족을 처리합니다.
+        //         // Firebase의 권한 거부(permission_denied) 에러가 잔액 부족을 의미할 수 있습니다.
+        //         if (error.Contains("permission_denied"))
+        //         {
+        //             Debug.LogWarning("[ProcessPurchase] 잔액이 부족하여 구매에 실패했습니다.");
+        //         }
+        //         else
+        //         {
+        //             Debug.LogError($"[ProcessPurchase] 코인 거래 실패: {error}");
+        //         }
+        //     }
+        // );
 
 
-// 아이템 인벤토리를 업데이트하는 헬퍼 메서드
-private void SetItemInventory(int itemId, BuyButtonBehaviour.ItemType itemType, string uid)
-{
-    string inventoryPath;
-    int level = 1; // 기본적으로 아이템을 획득하면 레벨 1로 설정
-
-    if (itemType == BuyButtonBehaviour.ItemType.Kart)
-    {
-        inventoryPath = DBRoutes.KartInventory(uid, itemId);
-    }
-    else // Unimo
-    {
-        inventoryPath = DBRoutes.UnimoInventory(uid, itemId);
-    }
-
-    DatabaseManager.Instance.SetOnMain(inventoryPath, level,
-        () => Debug.Log($"아이템 {itemId} 획득/강화 성공!"),
-        err => Debug.LogError($"아이템 {itemId} 획득 실패: {err}")
-    );
-}
-
-
-private string GetMoneyPath(MoneyType moneyType, string uid)
-{
-    return moneyType switch
-    {
-        MoneyType.Gold => DBRoutes.Gold(uid),
-        MoneyType.BlueHoneyGem => DBRoutes.BlueHoneyGem(uid),
-        _ => throw new ArgumentException("유효하지 않은 코인 타입입니다.")
-    };
-}
-
-
-// 분기가 여러개라서 메서드 분리
-private void TrySpendTransaction(MoneyType moneyType, int price, Action<bool> onDone)
-{
-    string path = moneyType switch
-    {
-        MoneyType.Gold => DBRoutes.Gold(CurrentUid),
-        MoneyType.BlueHoneyGem => DBRoutes.BlueHoneyGem(CurrentUid),
-        //MoneyType.Money3 => DBRoutes.Money3(CurrentUid),
-        _ => null
-    };
-
-    if (path == null)
-    {
-        onDone?.Invoke(false);
-        return;
-    }
-
-    DatabaseManager.Instance.RunTransactionOnMain(
-        path,
-        mutable =>
+        // 아이템 인벤토리를 업데이트하는 헬퍼 메서드
+        private void SetItemInventory(int itemId, BuyButtonBehaviour.ItemType itemType, string uid)
         {
-            long current = 0;
-            try
+            string inventoryPath;
+            int level = 1; // 기본적으로 아이템을 획득하면 레벨 1로 설정
+
+            if (itemType == BuyButtonBehaviour.ItemType.Kart)
             {
-                if (mutable.Value != null)
+                inventoryPath = DBRoutes.KartInventory(uid, itemId);
+            }
+            else // Unimo
+            {
+                inventoryPath = DBRoutes.UnimoInventory(uid, itemId);
+            }
+
+            DatabaseManager.Instance.SetOnMain(inventoryPath, level,
+                () => Debug.Log($"아이템 {itemId} 획득/강화 성공!"),
+                err => Debug.LogError($"아이템 {itemId} 획득 실패: {err}")
+            );
+        }
+
+
+        private string GetMoneyPath(MoneyType moneyType, string uid)
+        {
+            return moneyType switch
+            {
+                MoneyType.Gold => DBRoutes.Gold(uid),
+                MoneyType.BlueHoneyGem => DBRoutes.BlueHoneyGem(uid),
+                _ => throw new ArgumentException("유효하지 않은 코인 타입입니다.")
+            };
+        }
+
+
+        // 분기가 여러개라서 메서드 분리
+        private void TrySpendTransaction(MoneyType moneyType, int price, Action<bool> onDone)
+        {
+            string path = moneyType switch
+            {
+                MoneyType.Gold => DBRoutes.Gold(CurrentUid),
+                MoneyType.BlueHoneyGem => DBRoutes.BlueHoneyGem(CurrentUid),
+                //MoneyType.Money3 => DBRoutes.Money3(CurrentUid),
+                _ => null
+            };
+
+            if (path == null)
+            {
+                onDone?.Invoke(false);
+                return;
+            }
+
+            DatabaseManager.Instance.RunTransactionOnMain(
+                path,
+                mutable =>
                 {
-                    current = Convert.ToInt64(mutable.Value);
-                }
-            }
-            catch
-            {
-                // 파싱 실패는 0으로 간주
-            }
+                    long current = 0;
+                    try
+                    {
+                        if (mutable.Value != null)
+                        {
+                            current = Convert.ToInt64(mutable.Value);
+                        }
+                    }
+                    catch
+                    {
+                        // 파싱 실패는 0으로 간주
+                    }
 
-            // 부족하면 Abort
-            if (current < price)
-            {
-                // 구매할 수 없다
-                return TransactionResult.Abort();
-            }
+                    // 부족하면 Abort
+                    if (current < price)
+                    {
+                        // 구매할 수 없다
+                        return TransactionResult.Abort();
+                    }
 
-            // 충분하면 차감하고 Success
-            mutable.Value = current - price;
-            return TransactionResult.Success(mutable);
-        },
-        _ => onDone?.Invoke(true),
-        _ => onDone?.Invoke(false)
-    );
-}
+                    // 충분하면 차감하고 Success
+                    mutable.Value = current - price;
+                    return TransactionResult.Success(mutable);
+                },
+                _ => onDone?.Invoke(true),
+                _ => onDone?.Invoke(false)
+            );
+        }
     }
 }

--- a/Assets/00_WorkSpace/MSG/Scripts/Out Game UI/BuyButtonBehaviour.cs
+++ b/Assets/00_WorkSpace/MSG/Scripts/Out Game UI/BuyButtonBehaviour.cs
@@ -91,6 +91,9 @@ namespace MSG
 
         private void UpdateUI()
         {
+            Debug.Log($"Item ID: {_itemId}, Cost: {_itemCost}, Money Type: {_moneyType}");
+            Debug.Log($"_moneyType: {_moneyType}, GameMoneySprite null: {_gameMoneySprite == null}, CashSprite null: {_cashSprite == null}");
+            
             // _currentLevel 값이 이제 올바르게 설정되었으므로,
             // 이 값을 사용하여 UI 상태를 결정합니다.
             if (_currentLevel > 0)
@@ -100,12 +103,17 @@ namespace MSG
                 _buyButtonText.text = "보유 중";
                 _priceText.text = ""; // 가격 텍스트 숨기기
                 _currencyImage.enabled = false; // 화폐 이미지 숨기기
+
+                if (_moneyType != MoneyType.None)
+                {
+                    _currencyImage.sprite = (_moneyType == MoneyType.Gold) ? _gameMoneySprite : _cashSprite;
+                }
             }
             else
             {
                 // 아직 소유하지 않은 아이템
                 _buyButton.interactable = true;
-                _buyButtonText.text = "획득";
+                _buyButtonText.text = "구매하기";
                 _priceText.text = _itemCost.ToString();
                 _currencyImage.enabled = true; // 화폐 이미지 보이기
 

--- a/Assets/00_WorkSpace/MSG/Scripts/Out Game UI/ShopUIBehaviour.cs
+++ b/Assets/00_WorkSpace/MSG/Scripts/Out Game UI/ShopUIBehaviour.cs
@@ -99,7 +99,7 @@ namespace MSG.Deprecated
                 BuyButtonBehaviour button = Instantiate(_buyButtonPrefab, _unimoParent);
                 button.name = $"UnimoButton_{so.characterName}";
 
-                button.SetupButton(so.characterName, so.characterSprite, string.Empty);
+                button.SetupButton(so.characterName, so.characterSprite, string.Empty, so.currencyType);
                 button.SetupTypeAndId(BuyButtonBehaviour.ItemType.Unimo, so.characterId);
 
                 _unimoDict.Add(so.characterId, button);
@@ -115,7 +115,7 @@ namespace MSG.Deprecated
                 BuyButtonBehaviour button = Instantiate(_buyButtonPrefab, _kartParent);
                 button.name = $"KartButton_{so.carName}";
 
-                button.SetupButton(so.carName, so.kartSprite, string.Empty);
+                button.SetupButton(so.carName, so.kartSprite, string.Empty, so.currencyType);
                 button.SetupTypeAndId(BuyButtonBehaviour.ItemType.Kart, so.KartID);
 
                 _kartDict.Add(so.KartID, button);

--- a/Assets/00_WorkSpace/MSG/Scripts/SO/UnimoSO.cs
+++ b/Assets/00_WorkSpace/MSG/Scripts/SO/UnimoSO.cs
@@ -7,7 +7,7 @@ namespace MSG
 {
     public enum MoneyType
     {
-        Gold, BlueHoneyGem, //Money3
+        None, Gold, BlueHoneyGem, //Money3
     }
 
     [CreateAssetMenu(fileName = "UnimoSO", menuName = "ScriptableObjects/UnimoSO")]

--- a/Assets/00_WorkSpace/NTJ/Shop/ShopListManager.cs
+++ b/Assets/00_WorkSpace/NTJ/Shop/ShopListManager.cs
@@ -1,0 +1,161 @@
+using Firebase.Database;
+using MSG;
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+public class ShopListManager : PopupBase
+{
+    #region Fields and Properties
+    [Header("Register SO")]
+    [SerializeField] private UnimoCharacterSO[] _unimoSOs;
+    [SerializeField] private UnimoKartSO[] _kartSOs;
+
+    [Header("Button Parent")]
+    [SerializeField] private Transform _unimoParent;
+    [SerializeField] private Transform _kartParent;
+
+    [Header("Button Prefabs")]
+    [SerializeField] private BuyButtonBehaviour _unimoButtonPrefab; // 유니모용 버튼 프리팹
+    [SerializeField] private BuyButtonBehaviour _kartButtonPrefab; // 카트용 버튼 프리팹
+
+    [Header("Info Text")]
+    [SerializeField] private TMP_Text _infoText;
+
+    private readonly Dictionary<int, BuyButtonBehaviour> _unimoDict = new();
+    private readonly Dictionary<int, BuyButtonBehaviour> _kartDict = new();
+    private bool _isGenerated = false;
+
+    private Action _unsubUnimoInv;
+    private Action _unsubKartInv;
+
+    private string CurrentUid => FirebaseManager.Instance.Auth.CurrentUser.UserId;
+    #endregion
+
+    #region Unity Methods
+    private void OnEnable()
+    {
+        if (!_isGenerated)
+        {
+            GenerateButtons();
+            _isGenerated = true;
+        }
+        SubscribeInventory();
+    }
+
+    private void OnDisable()
+    {
+        UnsubscribeInventory();
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private void GenerateButtons()
+    {
+        // 유니모 버튼 생성
+        for (int i = 0; i < _unimoSOs.Length; i++)
+        {
+            UnimoCharacterSO so = _unimoSOs[i];
+            if (so == null) continue;
+
+            // Unimo 프리팹 사용
+            BuyButtonBehaviour button = Instantiate(_unimoButtonPrefab, _unimoParent);
+            button.name = $"UnimoButton_{so.characterName}";          
+            button.SetupButton(so.characterName, so.characterSprite, string.Empty, so.currencyType);
+            button.SetupTypeAndId(BuyButtonBehaviour.ItemType.Unimo, so.characterId);
+            _unimoDict.Add(so.characterId, button);
+            button.RefreshItemState(0);
+        }
+
+        // 카트 버튼 생성
+        for (int i = 0; i < _kartSOs.Length; i++)
+        {
+            UnimoKartSO so = _kartSOs[i];
+            if (so == null) continue;
+
+            BuyButtonBehaviour button = Instantiate(_kartButtonPrefab, _kartParent);
+            button.name = $"KartButton_{so.carName}";
+            button.SetupButton(so.carName, so.kartSprite, string.Empty, so.currencyType);
+            button.SetupTypeAndId(BuyButtonBehaviour.ItemType.Kart, so.KartID);
+            _kartDict.Add(so.KartID, button);
+            button.RefreshItemState(0);
+        }
+    }
+
+    private void SubscribeInventory()
+    {
+        _unsubUnimoInv = DatabaseManager.Instance.SubscribeValueChanged(
+            DBRoutes.UnimosInventory(CurrentUid),
+            onChanged: OnUnimoInventorySnapshot,
+            onError: (err) => Debug.LogWarning($"[ShopManager] 유니모 인벤토리 구독 오류: {err}")
+        );
+
+        _unsubKartInv = DatabaseManager.Instance.SubscribeValueChanged(
+            DBRoutes.KartsInventory(CurrentUid),
+            onChanged: OnKartInventorySnapshot,
+            onError: (err) => Debug.LogWarning($"[ShopManager] 카트 인벤토리 구독 오류: {err}")
+        );
+    }
+
+    private void UnsubscribeInventory()
+    {
+        _unsubUnimoInv?.Invoke();
+        _unsubKartInv?.Invoke();
+        _unsubUnimoInv = null;
+        _unsubKartInv = null;
+    }
+
+    private void OnUnimoInventorySnapshot(DataSnapshot snap)
+    {
+        var inventoryData = snap.Value as Dictionary<string, object> ?? new Dictionary<string, object>();
+
+        // 로컬 사전에 있는 모든 버튼을 반복합니다.
+        foreach (var kv in _unimoDict)
+        {
+            int unimoId = kv.Key;
+            BuyButtonBehaviour button = kv.Value;
+
+            // 현재 Unimo ID가 Firebase 데이터에 있는지 확인하세요.
+            if (inventoryData.ContainsKey(unimoId.ToString()))
+            {
+                // 만약 있다면, 사용자가 소유합니다. 레벨을 0보다 큰 값으로 설정하세요.
+                button.RefreshItemState(1); // 소유권을 나타내려면 1 이상으로 설정하세요.
+            }
+            else
+            {
+                // 해당 항목이 없으면 사용자가 소유하지 않은 것입니다. 값을 0으로 설정하세요.
+                button.RefreshItemState(0);
+            }
+        }
+    }
+
+    private void OnKartInventorySnapshot(DataSnapshot snap)
+    {
+        var inventoryData = snap.Value as Dictionary<string, object> ?? new Dictionary<string, object>();
+
+        foreach (var kv in _kartDict)
+        {
+            int kartId = kv.Key;
+            BuyButtonBehaviour button = kv.Value;
+
+            if (inventoryData.ContainsKey(kartId.ToString()))
+            {
+                // 카트의 경우 Firebase에서 실제 레벨을 가져옵니다.
+                int currentLevel = 0;
+                if (int.TryParse(inventoryData[kartId.ToString()].ToString(), out int level))
+                {
+                    currentLevel = level;
+                }
+                button.RefreshItemState(currentLevel);
+            }
+            else
+            {
+                button.RefreshItemState(0);
+            }
+        }
+    }
+    #endregion
+}

--- a/Assets/00_WorkSpace/NTJ/Shop/ShopListManager.cs
+++ b/Assets/00_WorkSpace/NTJ/Shop/ShopListManager.cs
@@ -64,6 +64,7 @@ public class ShopListManager : PopupBase
             button.SetupButton(so.characterName, so.characterSprite, string.Empty, so.currencyType);
             button.SetupTypeAndId(BuyButtonBehaviour.ItemType.Unimo, so.characterId);
             _unimoDict.Add(so.characterId, button);
+            button.RefreshItemState(0);
         }
 
         // 카트 버튼 생성
@@ -77,6 +78,7 @@ public class ShopListManager : PopupBase
             button.SetupButton(so.carName, so.kartSprite, string.Empty, so.currencyType);
             button.SetupTypeAndId(BuyButtonBehaviour.ItemType.Kart, so.KartID);
             _kartDict.Add(so.KartID, button);
+            button.RefreshItemState(0);
         }
     }
 

--- a/Assets/00_WorkSpace/NTJ/Shop/ShopListManager.cs.meta
+++ b/Assets/00_WorkSpace/NTJ/Shop/ShopListManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80f441addce2c6940806b2aed63cc8ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_WorkSpace/NTJ/Shop/ShopManager.cs
+++ b/Assets/00_WorkSpace/NTJ/Shop/ShopManager.cs
@@ -6,179 +6,179 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
-namespace MSG
-{
-    // ShopManager: 상점의 UI, 아이템 목록, 그리고 Firebase 연동을 모두 관리합니다.
-    public class ShopManager : PopupBase
-    {
-        #region Fields and Properties
-        [Header("Register SO")]
-        [SerializeField] private UnimoCharacterSO[] _unimoSOs;
-        [SerializeField] private UnimoKartSO[] _kartSOs;
-
-        [Header("Shop Panel")]
-        [SerializeField] private GameObject _unimoShopPanel;
-        [SerializeField] private GameObject _kartShopPanel;
-
-        [Header("Shop Panel Change Buttons")]
-        [SerializeField] private Toggle _unimoShopToggleButton;
-        [SerializeField] private Toggle _kartShopToggleButton;
-
-        [Header("Button Parent")]
-        [SerializeField] private Transform _unimoParent;
-        [SerializeField] private Transform _kartParent;
-        [SerializeField] private BuyButtonBehaviour _buyButtonPrefab;
-
-        [Header("Info Text")]
-        [SerializeField] private TMP_Text _infoText;
-
-        private readonly Dictionary<int, BuyButtonBehaviour> _unimoDict = new();
-        private readonly Dictionary<int, BuyButtonBehaviour> _kartDict = new();
-        private bool _isGenerated = false;
-
-        private Action _unsubUnimoInv;
-        private Action _unsubKartInv;
-
-        private string CurrentUid => FirebaseManager.Instance.Auth.CurrentUser.UserId;
-        #endregion
-
-        #region Unity Methods
-        private void OnEnable()
-        {
-            _unimoShopPanel.SetActive(_unimoShopToggleButton.isOn);
-            _kartShopPanel.SetActive(_kartShopToggleButton.isOn);
-
-            if (!_isGenerated)
-            {
-                GenerateButtons();
-                _isGenerated = true;
-            }
-            SubscribeInventory();
-        }
-
-        private void OnDisable()
-        {
-            UnsubscribeInventory();
-        }
-
-        private void Start()
-        {
-            _unimoShopToggleButton.onValueChanged.AddListener(isOn => TogglePanel(isOn, _unimoShopPanel));
-            _kartShopToggleButton.onValueChanged.AddListener(isOn => TogglePanel(isOn, _kartShopPanel));
-
-            _unimoShopToggleButton.isOn = true;
-            _kartShopToggleButton.isOn = false;
-        }
-        #endregion
-
-        #region Private Methods
-        private void TogglePanel(bool isOn, GameObject panel)
-        {
-            if (panel == null) return;
-            panel.SetActive(isOn);
-        }
-
-        private void GenerateButtons()
-        {
-            // 유니모 버튼 생성
-            for (int i = 0; i < _unimoSOs.Length; i++)
-            {
-                UnimoCharacterSO so = _unimoSOs[i];
-                if (so == null) continue;
-                BuyButtonBehaviour button = Instantiate(_buyButtonPrefab, _unimoParent);
-                button.name = $"UnimoButton_{so.characterName}";
-                button.SetupButton(so.characterName, so.characterSprite, string.Empty);
-                button.SetupTypeAndId(BuyButtonBehaviour.ItemType.Unimo, so.characterId);
-               // _unimoDict.Add(so.characterId, button);
-                button.RefreshItemState(0); // 모든 버튼을 "미보유" 상태로 초기화
-            }
-
-            // 카트 버튼 생성
-            for (int i = 0; i < _kartSOs.Length; i++)
-            {
-                UnimoKartSO so = _kartSOs[i];
-                if (so == null) continue;
-                BuyButtonBehaviour button = Instantiate(_buyButtonPrefab, _kartParent);
-                button.name = $"KartButton_{so.carName}";
-                button.SetupButton(so.carName, so.kartSprite, string.Empty);
-                button.SetupTypeAndId(BuyButtonBehaviour.ItemType.Kart, so.KartID);
-                _kartDict.Add(so.KartID, button);
-                button.RefreshItemState(0); // 모든 버튼을 "미보유" 상태로 초기화
-            }
-        }
-
-        private void SubscribeInventory()
-        {
-            _unsubUnimoInv = DatabaseManager.Instance.SubscribeValueChanged(
-                DBRoutes.UnimosInventory(CurrentUid),
-                onChanged: OnUnimoInventorySnapshot,
-                onError: (err) => Debug.LogWarning($"[ShopManager] 유니모 인벤토리 구독 오류: {err}")
-            );
-
-            _unsubKartInv = DatabaseManager.Instance.SubscribeValueChanged(
-                DBRoutes.KartsInventory(CurrentUid),
-                onChanged: OnKartInventorySnapshot,
-                onError: (err) => Debug.LogWarning($"[ShopManager] 카트 인벤토리 구독 오류: {err}")
-            );
-        }
-
-        private void UnsubscribeInventory()
-        {
-            _unsubUnimoInv?.Invoke();
-            _unsubKartInv?.Invoke();
-            _unsubUnimoInv = null;
-            _unsubKartInv = null;
-        }
-
-        private void OnUnimoInventorySnapshot(DataSnapshot snap)
-        {
-            var inventoryData = snap.Value as Dictionary<string, object> ?? new Dictionary<string, object>();
-
-            // 로컬 사전에 있는 모든 버튼을 반복합니다.
-            foreach (var kv in _unimoDict)
-            {
-                int unimoId = kv.Key;
-                BuyButtonBehaviour button = kv.Value;
-
-                // 현재 Unimo ID가 Firebase 데이터에 있는지 확인하세요.
-                if (inventoryData.ContainsKey(unimoId.ToString()))
-                {
-                    // 만약 있다면, 사용자가 소유합니다. 레벨을 0보다 큰 값으로 설정하세요.
-                    button.RefreshItemState(1); // 소유권을 나타내려면 1 이상으로 설정하세요.
-                }
-                else
-                {
-                    // 해당 항목이 없으면 사용자가 소유하지 않은 것입니다. 값을 0으로 설정하세요.
-                    button.RefreshItemState(0);
-                }
-            }
-        }
-
-        private void OnKartInventorySnapshot(DataSnapshot snap)
-        {
-            var inventoryData = snap.Value as Dictionary<string, object> ?? new Dictionary<string, object>();
-
-            foreach (var kv in _kartDict)
-            {
-                int kartId = kv.Key;
-                BuyButtonBehaviour button = kv.Value;
-
-                if (inventoryData.ContainsKey(kartId.ToString()))
-                {
-                    // 카트의 경우 Firebase에서 실제 레벨을 가져옵니다.
-                    int currentLevel = 0;
-                    if (int.TryParse(inventoryData[kartId.ToString()].ToString(), out int level))
-                    {
-                        currentLevel = level;
-                    }
-                    button.RefreshItemState(currentLevel);
-                }
-                else
-                {
-                    button.RefreshItemState(0);
-                }
-            }
-        }
-        #endregion
-    }
-}
+//namespace MSG
+//{
+//   // ShopManager: 상점의 UI, 아이템 목록, 그리고 Firebase 연동을 모두 관리합니다.
+//   public class ShopManager : PopupBase
+//   {
+//       #region Fields and Properties
+//       [Header("Register SO")]
+//       [SerializeField] private UnimoCharacterSO[] _unimoSOs;
+//       [SerializeField] private UnimoKartSO[] _kartSOs;
+//
+//       [Header("Shop Panel")]
+//       [SerializeField] private GameObject _unimoShopPanel;
+//       [SerializeField] private GameObject _kartShopPanel;
+//
+//       [Header("Shop Panel Change Buttons")]
+//       [SerializeField] private Toggle _unimoShopToggleButton;
+//       [SerializeField] private Toggle _kartShopToggleButton;
+//
+//       [Header("Button Parent")]
+//       [SerializeField] private Transform _unimoParent;
+//       [SerializeField] private Transform _kartParent;
+//       [SerializeField] private BuyButtonBehaviour _buyButtonPrefab;
+//
+//       [Header("Info Text")]
+//       [SerializeField] private TMP_Text _infoText;
+//
+//       private readonly Dictionary<int, BuyButtonBehaviour> _unimoDict = new();
+//       private readonly Dictionary<int, BuyButtonBehaviour> _kartDict = new();
+//       private bool _isGenerated = false;
+//
+//       private Action _unsubUnimoInv;
+//       private Action _unsubKartInv;
+//
+//       private string CurrentUid => FirebaseManager.Instance.Auth.CurrentUser.UserId;
+//       #endregion
+//
+//       #region Unity Methods
+//       private void OnEnable()
+//       {
+//           _unimoShopPanel.SetActive(_unimoShopToggleButton.isOn);
+//           _kartShopPanel.SetActive(_kartShopToggleButton.isOn);
+//
+//           if (!_isGenerated)
+//           {
+//               GenerateButtons();
+//               _isGenerated = true;
+//           }
+//           SubscribeInventory();
+//       }
+//
+//       private void OnDisable()
+//       {
+//           UnsubscribeInventory();
+//       }
+//
+//       private void Start()
+//       {
+//           _unimoShopToggleButton.onValueChanged.AddListener(isOn => TogglePanel(isOn, _unimoShopPanel));
+//           _kartShopToggleButton.onValueChanged.AddListener(isOn => TogglePanel(isOn, _kartShopPanel));
+//
+//           _unimoShopToggleButton.isOn = true;
+//           _kartShopToggleButton.isOn = false;
+//       }
+//       #endregion
+//
+//       #region Private Methods
+//       private void TogglePanel(bool isOn, GameObject panel)
+//       {
+//           if (panel == null) return;
+//           panel.SetActive(isOn);
+//       }
+//
+//       private void GenerateButtons()
+//       {
+//           // 유니모 버튼 생성
+//           for (int i = 0; i < _unimoSOs.Length; i++)
+//           {
+//               UnimoCharacterSO so = _unimoSOs[i];
+//               if (so == null) continue;
+//               BuyButtonBehaviour button = Instantiate(_buyButtonPrefab, _unimoParent);
+//               button.name = $"UnimoButton_{so.characterName}";
+//               button.SetupButton(so.characterName, so.characterSprite, string.Empty);
+//               button.SetupTypeAndId(BuyButtonBehaviour.ItemType.Unimo, so.characterId);
+//              // _unimoDict.Add(so.characterId, button);
+//               button.RefreshItemState(0); // 모든 버튼을 "미보유" 상태로 초기화
+//           }
+//
+//           // 카트 버튼 생성
+//           for (int i = 0; i < _kartSOs.Length; i++)
+//           {
+//               UnimoKartSO so = _kartSOs[i];
+//               if (so == null) continue;
+//               BuyButtonBehaviour button = Instantiate(_buyButtonPrefab, _kartParent);
+//               button.name = $"KartButton_{so.carName}";
+//               button.SetupButton(so.carName, so.kartSprite, string.Empty);
+//               button.SetupTypeAndId(BuyButtonBehaviour.ItemType.Kart, so.KartID);
+//               _kartDict.Add(so.KartID, button);
+//               button.RefreshItemState(0); // 모든 버튼을 "미보유" 상태로 초기화
+//           }
+//       }
+//
+//       private void SubscribeInventory()
+//       {
+//           _unsubUnimoInv = DatabaseManager.Instance.SubscribeValueChanged(
+//               DBRoutes.UnimosInventory(CurrentUid),
+//               onChanged: OnUnimoInventorySnapshot,
+//               onError: (err) => Debug.LogWarning($"[ShopManager] 유니모 인벤토리 구독 오류: {err}")
+//           );
+//
+//           _unsubKartInv = DatabaseManager.Instance.SubscribeValueChanged(
+//               DBRoutes.KartsInventory(CurrentUid),
+//               onChanged: OnKartInventorySnapshot,
+//               onError: (err) => Debug.LogWarning($"[ShopManager] 카트 인벤토리 구독 오류: {err}")
+//           );
+//       }
+//
+//       private void UnsubscribeInventory()
+//       {
+//           _unsubUnimoInv?.Invoke();
+//           _unsubKartInv?.Invoke();
+//           _unsubUnimoInv = null;
+//           _unsubKartInv = null;
+//       }
+//
+//       private void OnUnimoInventorySnapshot(DataSnapshot snap)
+//       {
+//           var inventoryData = snap.Value as Dictionary<string, object> ?? new Dictionary<string, object>();
+//
+//           // 로컬 사전에 있는 모든 버튼을 반복합니다.
+//           foreach (var kv in _unimoDict)
+//           {
+//               int unimoId = kv.Key;
+//               BuyButtonBehaviour button = kv.Value;
+//
+//               // 현재 Unimo ID가 Firebase 데이터에 있는지 확인하세요.
+//               if (inventoryData.ContainsKey(unimoId.ToString()))
+//               {
+//                   // 만약 있다면, 사용자가 소유합니다. 레벨을 0보다 큰 값으로 설정하세요.
+//                   button.RefreshItemState(1); // 소유권을 나타내려면 1 이상으로 설정하세요.
+//               }
+//               else
+//               {
+//                   // 해당 항목이 없으면 사용자가 소유하지 않은 것입니다. 값을 0으로 설정하세요.
+//                   button.RefreshItemState(0);
+//               }
+//           }
+//       }
+//
+//       private void OnKartInventorySnapshot(DataSnapshot snap)
+//       {
+//           var inventoryData = snap.Value as Dictionary<string, object> ?? new Dictionary<string, object>();
+//
+//           foreach (var kv in _kartDict)
+//           {
+//               int kartId = kv.Key;
+//               BuyButtonBehaviour button = kv.Value;
+//
+//               if (inventoryData.ContainsKey(kartId.ToString()))
+//               {
+//                   // 카트의 경우 Firebase에서 실제 레벨을 가져옵니다.
+//                   int currentLevel = 0;
+//                   if (int.TryParse(inventoryData[kartId.ToString()].ToString(), out int level))
+//                   {
+//                       currentLevel = level;
+//                   }
+//                   button.RefreshItemState(currentLevel);
+//               }
+//               else
+//               {
+//                   button.RefreshItemState(0);
+//               }
+//           }
+//       }
+//       #endregion
+//   }
+//

--- a/Assets/00_WorkSpace/NTJ/ShopList(Kart).prefab
+++ b/Assets/00_WorkSpace/NTJ/ShopList(Kart).prefab
@@ -1,0 +1,1374 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &75330358328262865
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6444236054497172120}
+  - component: {fileID: 3585499093680369036}
+  - component: {fileID: 6969892510879357850}
+  - component: {fileID: 2520998659361704690}
+  m_Layer: 5
+  m_Name: ShopList(Kart)BG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6444236054497172120
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 75330358328262865}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2868282689739333600}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 190, y: -225}
+  m_SizeDelta: {x: 380, y: 450}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3585499093680369036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 75330358328262865}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b42570416bdca4697b2749e5bf8c5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debug: 0
+  data:
+    id: 1059:3764
+    projectId: Vn06HxPJYpBaFJ1bk5AupZ
+    names:
+      names:
+        m_Keys: 0a000000000000000400000007000000010000000200000005000000080000000300000006000000
+        m_Values:
+        - Rectangle 31
+        - Rectangle 31
+        - 4742c142cbbc4e098948973a62270966
+        - rectangle_31
+        - _rectangle31_1
+        - Rectangle31_1
+        - Rectangle31_1
+        - 
+        - Rectangle 31 4x -1881682822.png
+        - style-Rectangle 31-1881682822
+    tags: c9000000
+    fcuImageType: 1
+    buttonComponent: 0
+    childIndexes: 
+    fcu: {fileID: 0}
+    gameObject: {fileID: 75330358328262865}
+    hash: -1881682822
+    hierarchy:
+    - Index: -1
+      Name: Frame 180
+      Guid: ed1c3ebcdf134bd9886167344dd1ee9d
+    - Index: 10
+      Name: Frame 197
+      Guid: 91a79e8469634d2daf5d01b0f6e4fa2b
+    - Index: 0
+      Name: Group 9
+      Guid: 44b6f4887f944ec89ebb04646e8cd038
+    - Index: 0
+      Name: Group 115
+      Guid: 29dc6a0bee5142f6a81481d91d9b53e3
+    - Index: 0
+      Name: Rectangle 31
+      Guid: 4742c142cbbc4e098948973a62270966
+    rootFrameGO: {fileID: 0}
+    hashDataTree: 
+    parentIndex: 0
+    uguiTransformData:
+      anchorMin: {x: 0, y: 0}
+      anchorMax: {x: 0, y: 0}
+      anchoredPosition: {x: 0, y: 0}
+      sizeDelta: {x: 0, y: 0, z: 0}
+      localRotation: {x: 0, y: 0, z: 0, w: 0}
+      localPosition: {x: 0, y: 0, z: 0}
+      localScale: {x: 0, y: 0, z: 0}
+    graphic:
+      hasFill: 0
+      hasStroke: 0
+      hasSingleColor: 0
+      hasSingleGradient: 0
+      fill:
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      stroke:
+        align: 0
+        weight: 0
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      spriteSingleColor: {r: 0, g: 0, b: 0, a: 0}
+      fillAlpha1: 0
+    rectGameObject: {fileID: 0}
+    spriteSize: {x: 0, y: 0}
+    rect:
+      _position: {x: 0, y: 0}
+      _size: {x: 0, y: 0}
+      _angle: 0
+      _absoluteAngle: 0
+    spritePath: 
+    link: 
+    tagReasons: []
+    downloadableReason: 
+    generativeReason: 
+    downloadAttempsCount: 0
+    isDuplicate: 1
+    isMutual: 0
+    isEmpty: 0
+    needDownload: 1
+    needGenerate: 0
+    forceImage: 0
+    isOverlappedByStroke: 0
+    forceContainer: 0
+    isInsideDownloadable: 1
+    hasFontAsset: 0
+    imageFormat: 0
+    scale: 0
+    maxSpriteSize: {x: 0, y: 0}
+    parentTransformRect: {fileID: 0}
+    parentTransform: {fileID: 0}
+    partOfPrefab: 0
+--- !u!222 &6969892510879357850
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 75330358328262865}
+  m_CullTransparentMesh: 1
+--- !u!114 &2520998659361704690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 75330358328262865}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 41bc1ce8da9e87a4fa340d902394e0df, type: 2}
+  m_Color: {r: 0.8894231, g: 0.8894231, b: 0.8894231, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5121b72252a83544bb560a4a7ef2df92, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1259072046099419650
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1776020475415195923}
+  - component: {fileID: 4011353049157506541}
+  - component: {fileID: 7939762219589516947}
+  - component: {fileID: 7310721313692327667}
+  m_Layer: 5
+  m_Name: ShopList(Kart)MoneyType
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1776020475415195923
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259072046099419650}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2868282689739333600}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 98.5, y: -359.5}
+  m_SizeDelta: {x: 45, y: 45}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4011353049157506541
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259072046099419650}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b42570416bdca4697b2749e5bf8c5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debug: 0
+  data:
+    id: 1059:3859
+    projectId: Vn06HxPJYpBaFJ1bk5AupZ
+    names:
+      names:
+        m_Keys: 0a000000000000000400000007000000010000000200000005000000080000000300000006000000
+        m_Values:
+        - Yellow
+        - Yellow
+        - ffebb2a45c6f437a9262cfbbd5234649
+        - yellow
+        - _yellow_2
+        - Yellow_2
+        - Yellow_2
+        - 
+        - Yellow 4x -678305129.png
+        - style-Yellow-678305129
+    tags: 66000000c9000000
+    fcuImageType: 1
+    buttonComponent: 0
+    childIndexes: 
+    fcu: {fileID: 0}
+    gameObject: {fileID: 1259072046099419650}
+    hash: -678305129
+    hierarchy:
+    - Index: -1
+      Name: Frame 180
+      Guid: ed1c3ebcdf134bd9886167344dd1ee9d
+    - Index: 10
+      Name: Frame 197
+      Guid: 91a79e8469634d2daf5d01b0f6e4fa2b
+    - Index: 0
+      Name: Group 9
+      Guid: 44b6f4887f944ec89ebb04646e8cd038
+    - Index: 0
+      Name: Group 115
+      Guid: 29dc6a0bee5142f6a81481d91d9b53e3
+    - Index: 3
+      Name: Yellow
+      Guid: ffebb2a45c6f437a9262cfbbd5234649
+    rootFrameGO: {fileID: 0}
+    hashDataTree: 
+    parentIndex: 0
+    uguiTransformData:
+      anchorMin: {x: 0, y: 0}
+      anchorMax: {x: 0, y: 0}
+      anchoredPosition: {x: 0, y: 0}
+      sizeDelta: {x: 0, y: 0, z: 0}
+      localRotation: {x: 0, y: 0, z: 0, w: 0}
+      localPosition: {x: 0, y: 0, z: 0}
+      localScale: {x: 0, y: 0, z: 0}
+    graphic:
+      hasFill: 0
+      hasStroke: 0
+      hasSingleColor: 0
+      hasSingleGradient: 0
+      fill:
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      stroke:
+        align: 0
+        weight: 0
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      spriteSingleColor: {r: 0, g: 0, b: 0, a: 0}
+      fillAlpha1: 0
+    rectGameObject: {fileID: 0}
+    spriteSize: {x: 0, y: 0}
+    rect:
+      _position: {x: 0, y: 0}
+      _size: {x: 0, y: 0}
+      _angle: 0
+      _absoluteAngle: 0
+    spritePath: 
+    link: 
+    tagReasons: []
+    downloadableReason: 
+    generativeReason: 
+    downloadAttempsCount: 0
+    isDuplicate: 1
+    isMutual: 0
+    isEmpty: 0
+    needDownload: 1
+    needGenerate: 0
+    forceImage: 0
+    isOverlappedByStroke: 0
+    forceContainer: 0
+    isInsideDownloadable: 1
+    hasFontAsset: 0
+    imageFormat: 0
+    scale: 0
+    maxSpriteSize: {x: 0, y: 0}
+    parentTransformRect: {fileID: 0}
+    parentTransform: {fileID: 0}
+    partOfPrefab: 0
+--- !u!222 &7939762219589516947
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259072046099419650}
+  m_CullTransparentMesh: 1
+--- !u!114 &7310721313692327667
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259072046099419650}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 41bc1ce8da9e87a4fa340d902394e0df, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 37ca940deea86f14aab10d2def6fcfec, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1847459755702258909
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5292368860846866219}
+  - component: {fileID: 5893661645634605194}
+  - component: {fileID: 3884216084504351875}
+  - component: {fileID: 650068455061598522}
+  - component: {fileID: 5099157954460730611}
+  m_Layer: 5
+  m_Name: ShopList(Kart)Price
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5292368860846866219
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1847459755702258909}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2868282689739333600}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 214, y: -360.5}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5893661645634605194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1847459755702258909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b42570416bdca4697b2749e5bf8c5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debug: 0
+  data:
+    id: 1059:3860
+    projectId: Vn06HxPJYpBaFJ1bk5AupZ
+    names:
+      names:
+        m_Keys: 0a000000000000000400000007000000010000000200000005000000080000000300000006000000
+        m_Values:
+        - 999,999,999
+        - GameObject 10593860
+        - 6e34410d42fa46b3855c0bfb024a6c63
+        - 
+        - _gameObject10593_7
+        - GameObject105938
+        - GameObject105938
+        - TextMeshPro YANGJIN-Medium-28-LeftBottom-Black255
+        - GameObject 10593860
+        - style-GameObject 10593860-1672449956
+    tags: c800000065000000
+    fcuImageType: 0
+    buttonComponent: 0
+    childIndexes: 
+    fcu: {fileID: 0}
+    gameObject: {fileID: 1847459755702258909}
+    hash: 1672449956
+    hierarchy:
+    - Index: -1
+      Name: Frame 180
+      Guid: ed1c3ebcdf134bd9886167344dd1ee9d
+    - Index: 10
+      Name: Frame 197
+      Guid: 91a79e8469634d2daf5d01b0f6e4fa2b
+    - Index: 0
+      Name: Group 9
+      Guid: 44b6f4887f944ec89ebb04646e8cd038
+    - Index: 0
+      Name: Group 115
+      Guid: 29dc6a0bee5142f6a81481d91d9b53e3
+    - Index: 4
+      Name: GameObject 10593860
+      Guid: 6e34410d42fa46b3855c0bfb024a6c63
+    rootFrameGO: {fileID: 0}
+    hashDataTree: 
+    parentIndex: 0
+    uguiTransformData:
+      anchorMin: {x: 0, y: 0}
+      anchorMax: {x: 0, y: 0}
+      anchoredPosition: {x: 0, y: 0}
+      sizeDelta: {x: 0, y: 0, z: 0}
+      localRotation: {x: 0, y: 0, z: 0, w: 0}
+      localPosition: {x: 0, y: 0, z: 0}
+      localScale: {x: 0, y: 0, z: 0}
+    graphic:
+      hasFill: 0
+      hasStroke: 0
+      hasSingleColor: 0
+      hasSingleGradient: 0
+      fill:
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      stroke:
+        align: 0
+        weight: 0
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      spriteSingleColor: {r: 0, g: 0, b: 0, a: 0}
+      fillAlpha1: 0
+    rectGameObject: {fileID: 0}
+    spriteSize: {x: 0, y: 0}
+    rect:
+      _position: {x: 0, y: 0}
+      _size: {x: 0, y: 0}
+      _angle: 0
+      _absoluteAngle: 0
+    spritePath: 
+    link: 
+    tagReasons: []
+    downloadableReason: 
+    generativeReason: 
+    downloadAttempsCount: 0
+    isDuplicate: 1
+    isMutual: 0
+    isEmpty: 0
+    needDownload: 0
+    needGenerate: 0
+    forceImage: 0
+    isOverlappedByStroke: 0
+    forceContainer: 0
+    isInsideDownloadable: 0
+    hasFontAsset: 0
+    imageFormat: 0
+    scale: 0
+    maxSpriteSize: {x: 0, y: 0}
+    parentTransformRect: {fileID: 0}
+    parentTransform: {fileID: 0}
+    partOfPrefab: 0
+--- !u!114 &3884216084504351875
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1847459755702258909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!222 &650068455061598522
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1847459755702258909}
+  m_CullTransparentMesh: 1
+--- !u!114 &5099157954460730611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1847459755702258909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 999,999,999
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 934dd59316476cc4bb5148676dd507ef, type: 2}
+  m_sharedMaterial: {fileID: 6497309756745478032, guid: 934dd59316476cc4bb5148676dd507ef,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4280492835
+  m_fontColor: {r: 0.13725491, g: 0.13725491, b: 0.13725491, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 1
+  m_fontSizeMax: 28
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 1024
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 28.34
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3266456279481873554
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3094603065491638725}
+  - component: {fileID: 2048137538944892358}
+  - component: {fileID: 4670915792333421588}
+  m_Layer: 5
+  m_Name: ShopList(Kart)Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3094603065491638725
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3266456279481873554}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 443881760089758774}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 278, y: 278}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2048137538944892358
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3266456279481873554}
+  m_CullTransparentMesh: 1
+--- !u!114 &4670915792333421588
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3266456279481873554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3617818226408430869
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 443881760089758774}
+  - component: {fileID: 8239162599232123729}
+  - component: {fileID: 7269895924583769621}
+  - component: {fileID: 2552365923641003215}
+  m_Layer: 5
+  m_Name: ShopList(Kart)BG2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &443881760089758774
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3617818226408430869}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3094603065491638725}
+  m_Father: {fileID: 2868282689739333600}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 190, y: -191}
+  m_SizeDelta: {x: 278, y: 278}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8239162599232123729
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3617818226408430869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b42570416bdca4697b2749e5bf8c5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debug: 0
+  data:
+    id: 1059:3765
+    projectId: Vn06HxPJYpBaFJ1bk5AupZ
+    names:
+      names:
+        m_Keys: 0a000000000000000400000007000000010000000200000005000000080000000300000006000000
+        m_Values:
+        - Rectangle 143
+        - Rectangle 143
+        - 63cf9f55460a486ba33f85e43ddc8631
+        - rectangle_143
+        - _rectangle143
+        - Rectangle143
+        - Rectangle143
+        - 
+        - Rectangle 143
+        - style-Rectangle 143-1711544546
+    tags: c9000000
+    fcuImageType: 2
+    buttonComponent: 0
+    childIndexes: 
+    fcu: {fileID: 0}
+    gameObject: {fileID: 3617818226408430869}
+    hash: 1711544546
+    hierarchy:
+    - Index: -1
+      Name: Frame 180
+      Guid: ed1c3ebcdf134bd9886167344dd1ee9d
+    - Index: 10
+      Name: Frame 197
+      Guid: 91a79e8469634d2daf5d01b0f6e4fa2b
+    - Index: 0
+      Name: Group 9
+      Guid: 44b6f4887f944ec89ebb04646e8cd038
+    - Index: 0
+      Name: Group 115
+      Guid: 29dc6a0bee5142f6a81481d91d9b53e3
+    - Index: 1
+      Name: Rectangle 143
+      Guid: 63cf9f55460a486ba33f85e43ddc8631
+    rootFrameGO: {fileID: 0}
+    hashDataTree: 
+    parentIndex: 0
+    uguiTransformData:
+      anchorMin: {x: 0, y: 0}
+      anchorMax: {x: 0, y: 0}
+      anchoredPosition: {x: 0, y: 0}
+      sizeDelta: {x: 0, y: 0, z: 0}
+      localRotation: {x: 0, y: 0, z: 0, w: 0}
+      localPosition: {x: 0, y: 0, z: 0}
+      localScale: {x: 0, y: 0, z: 0}
+    graphic:
+      hasFill: 0
+      hasStroke: 0
+      hasSingleColor: 0
+      hasSingleGradient: 0
+      fill:
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      stroke:
+        align: 0
+        weight: 0
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      spriteSingleColor: {r: 0, g: 0, b: 0, a: 0}
+      fillAlpha1: 0
+    rectGameObject: {fileID: 0}
+    spriteSize: {x: 0, y: 0}
+    rect:
+      _position: {x: 0, y: 0}
+      _size: {x: 0, y: 0}
+      _angle: 0
+      _absoluteAngle: 0
+    spritePath: 
+    link: 
+    tagReasons: []
+    downloadableReason: 
+    generativeReason: 
+    downloadAttempsCount: 0
+    isDuplicate: 1
+    isMutual: 0
+    isEmpty: 0
+    needDownload: 0
+    needGenerate: 0
+    forceImage: 0
+    isOverlappedByStroke: 0
+    forceContainer: 0
+    isInsideDownloadable: 0
+    hasFontAsset: 0
+    imageFormat: 0
+    scale: 0
+    maxSpriteSize: {x: 0, y: 0}
+    parentTransformRect: {fileID: 0}
+    parentTransform: {fileID: 0}
+    partOfPrefab: 0
+--- !u!222 &7269895924583769621
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3617818226408430869}
+  m_CullTransparentMesh: 1
+--- !u!114 &2552365923641003215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3617818226408430869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 41bc1ce8da9e87a4fa340d902394e0df, type: 2}
+  m_Color: {r: 1, g: 0.6570511, b: 0.6570511, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4226686437539964634
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2868282689739333600}
+  - component: {fileID: 3361064993690510581}
+  - component: {fileID: 7490808812642202199}
+  - component: {fileID: 507792839905570533}
+  m_Layer: 5
+  m_Name: ShopList(Kart)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2868282689739333600
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4226686437539964634}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6444236054497172120}
+  - {fileID: 443881760089758774}
+  - {fileID: 7275778302366066120}
+  - {fileID: 1776020475415195923}
+  - {fileID: 5292368860846866219}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 380, y: 450}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3361064993690510581
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4226686437539964634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b42570416bdca4697b2749e5bf8c5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debug: 0
+  data:
+    id: 1059:3763
+    projectId: Vn06HxPJYpBaFJ1bk5AupZ
+    names:
+      names:
+        m_Keys: 0a000000000000000400000007000000010000000200000005000000080000000300000006000000
+        m_Values:
+        - Group 115
+        - Group 115
+        - 29dc6a0bee5142f6a81481d91d9b53e3
+        - group_115
+        - _group115
+        - Group115
+        - Group115
+        - 
+        - Group 115
+        - style-Group 115-531276359
+    tags: 01000000
+    fcuImageType: 0
+    buttonComponent: 0
+    childIndexes: 4100000042000000430000004400000045000000
+    fcu: {fileID: 0}
+    gameObject: {fileID: 4226686437539964634}
+    hash: -531276359
+    hierarchy:
+    - Index: -1
+      Name: Frame 180
+      Guid: ed1c3ebcdf134bd9886167344dd1ee9d
+    - Index: 10
+      Name: Frame 197
+      Guid: 91a79e8469634d2daf5d01b0f6e4fa2b
+    - Index: 0
+      Name: Group 9
+      Guid: 44b6f4887f944ec89ebb04646e8cd038
+    - Index: 0
+      Name: Group 115
+      Guid: 29dc6a0bee5142f6a81481d91d9b53e3
+    rootFrameGO: {fileID: 0}
+    hashDataTree: 
+    parentIndex: 0
+    uguiTransformData:
+      anchorMin: {x: 0, y: 0}
+      anchorMax: {x: 0, y: 0}
+      anchoredPosition: {x: 0, y: 0}
+      sizeDelta: {x: 0, y: 0, z: 0}
+      localRotation: {x: 0, y: 0, z: 0, w: 0}
+      localPosition: {x: 0, y: 0, z: 0}
+      localScale: {x: 0, y: 0, z: 0}
+    graphic:
+      hasFill: 0
+      hasStroke: 0
+      hasSingleColor: 0
+      hasSingleGradient: 0
+      fill:
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      stroke:
+        align: 0
+        weight: 0
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      spriteSingleColor: {r: 0, g: 0, b: 0, a: 0}
+      fillAlpha1: 0
+    rectGameObject: {fileID: 0}
+    spriteSize: {x: 0, y: 0}
+    rect:
+      _position: {x: 0, y: 0}
+      _size: {x: 0, y: 0}
+      _angle: 0
+      _absoluteAngle: 0
+    spritePath: 
+    link: 
+    tagReasons:
+    - children not empty
+    downloadableReason: 
+    generativeReason: 
+    downloadAttempsCount: 0
+    isDuplicate: 1
+    isMutual: 0
+    isEmpty: 0
+    needDownload: 0
+    needGenerate: 0
+    forceImage: 0
+    isOverlappedByStroke: 0
+    forceContainer: 0
+    isInsideDownloadable: 0
+    hasFontAsset: 0
+    imageFormat: 0
+    scale: 0
+    maxSpriteSize: {x: 0, y: 0}
+    parentTransformRect: {fileID: 0}
+    parentTransform: {fileID: 0}
+    partOfPrefab: 0
+--- !u!114 &7490808812642202199
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4226686437539964634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af697d6bfd90684438f5dfe4b213d39e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemType: 0
+  _itemName: {fileID: 4888566950833713472}
+  _itemIcon: {fileID: 4670915792333421588}
+  _currencyImage: {fileID: 7310721313692327667}
+  _priceText: {fileID: 5099157954460730611}
+  _buyButtonText: {fileID: 0}
+  _buyButton: {fileID: 507792839905570533}
+  _gameMoneySprite: {fileID: 21300000, guid: 37ca940deea86f14aab10d2def6fcfec, type: 3}
+  _cashSprite: {fileID: 21300000, guid: d46471f8ea6780240a8149a1432a41a8, type: 3}
+--- !u!114 &507792839905570533
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4226686437539964634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2520998659361704690}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &8807392156226058120
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7275778302366066120}
+  - component: {fileID: 1347447429897907109}
+  - component: {fileID: 5064113815959313866}
+  - component: {fileID: 4907829797719709911}
+  - component: {fileID: 4888566950833713472}
+  m_Layer: 5
+  m_Name: ShopList(Kart)Name
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7275778302366066120
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8807392156226058120}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2868282689739333600}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 190, y: -406.5}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1347447429897907109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8807392156226058120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b42570416bdca4697b2749e5bf8c5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debug: 0
+  data:
+    id: 1059:3766
+    projectId: Vn06HxPJYpBaFJ1bk5AupZ
+    names:
+      names:
+        m_Keys: 0a000000000000000400000007000000010000000200000005000000080000000300000006000000
+        m_Values:
+        - "\uC774\uB984\uC774\uB984\uC774\uB984\uC774\uB984\uC774\uB984"
+        - GameObject 10593766
+        - 3b7986f7c89e4e00b138de3e848f7559
+        - 
+        - _gameObject10593_5
+        - GameObject105937_2
+        - GameObject105937_2
+        - TextMeshPro YANGJIN-Medium-36-CenterBottom-Black255
+        - GameObject 10593766
+        - style-GameObject 10593766-1198722305
+    tags: c800000065000000
+    fcuImageType: 0
+    buttonComponent: 0
+    childIndexes: 
+    fcu: {fileID: 0}
+    gameObject: {fileID: 8807392156226058120}
+    hash: -1198722305
+    hierarchy:
+    - Index: -1
+      Name: Frame 180
+      Guid: ed1c3ebcdf134bd9886167344dd1ee9d
+    - Index: 10
+      Name: Frame 197
+      Guid: 91a79e8469634d2daf5d01b0f6e4fa2b
+    - Index: 0
+      Name: Group 9
+      Guid: 44b6f4887f944ec89ebb04646e8cd038
+    - Index: 0
+      Name: Group 115
+      Guid: 29dc6a0bee5142f6a81481d91d9b53e3
+    - Index: 2
+      Name: GameObject 10593766
+      Guid: 3b7986f7c89e4e00b138de3e848f7559
+    rootFrameGO: {fileID: 0}
+    hashDataTree: 
+    parentIndex: 0
+    uguiTransformData:
+      anchorMin: {x: 0, y: 0}
+      anchorMax: {x: 0, y: 0}
+      anchoredPosition: {x: 0, y: 0}
+      sizeDelta: {x: 0, y: 0, z: 0}
+      localRotation: {x: 0, y: 0, z: 0, w: 0}
+      localPosition: {x: 0, y: 0, z: 0}
+      localScale: {x: 0, y: 0, z: 0}
+    graphic:
+      hasFill: 0
+      hasStroke: 0
+      hasSingleColor: 0
+      hasSingleGradient: 0
+      fill:
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      stroke:
+        align: 0
+        weight: 0
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      spriteSingleColor: {r: 0, g: 0, b: 0, a: 0}
+      fillAlpha1: 0
+    rectGameObject: {fileID: 0}
+    spriteSize: {x: 0, y: 0}
+    rect:
+      _position: {x: 0, y: 0}
+      _size: {x: 0, y: 0}
+      _angle: 0
+      _absoluteAngle: 0
+    spritePath: 
+    link: 
+    tagReasons: []
+    downloadableReason: 
+    generativeReason: 
+    downloadAttempsCount: 0
+    isDuplicate: 1
+    isMutual: 0
+    isEmpty: 0
+    needDownload: 0
+    needGenerate: 0
+    forceImage: 0
+    isOverlappedByStroke: 0
+    forceContainer: 0
+    isInsideDownloadable: 0
+    hasFontAsset: 0
+    imageFormat: 0
+    scale: 0
+    maxSpriteSize: {x: 0, y: 0}
+    parentTransformRect: {fileID: 0}
+    parentTransform: {fileID: 0}
+    partOfPrefab: 0
+--- !u!114 &5064113815959313866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8807392156226058120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!222 &4907829797719709911
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8807392156226058120}
+  m_CullTransparentMesh: 1
+--- !u!114 &4888566950833713472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8807392156226058120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uC774\uB984\uC774\uB984\uC774\uB984\uC774\uB984\uC774\uB984"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 934dd59316476cc4bb5148676dd507ef, type: 2}
+  m_sharedMaterial: {fileID: 6497309756745478032, guid: 934dd59316476cc4bb5148676dd507ef,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4280492835
+  m_fontColor: {r: 0.13725491, g: 0.13725491, b: 0.13725491, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 1
+  m_fontSizeMax: 36
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 1024
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 99.34
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/Assets/00_WorkSpace/NTJ/ShopList(Kart).prefab.meta
+++ b/Assets/00_WorkSpace/NTJ/ShopList(Kart).prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c5ce0b41f1ae9f449ba1eb1742ef709a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_WorkSpace/NTJ/ShopList(Unimo).prefab
+++ b/Assets/00_WorkSpace/NTJ/ShopList(Unimo).prefab
@@ -1,0 +1,1374 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &75330358328262865
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6444236054497172120}
+  - component: {fileID: 3585499093680369036}
+  - component: {fileID: 6969892510879357850}
+  - component: {fileID: 2520998659361704690}
+  m_Layer: 5
+  m_Name: ShopList(Unimo)BG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6444236054497172120
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 75330358328262865}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2868282689739333600}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 190, y: -225}
+  m_SizeDelta: {x: 380, y: 450}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3585499093680369036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 75330358328262865}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b42570416bdca4697b2749e5bf8c5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debug: 0
+  data:
+    id: 1059:3764
+    projectId: Vn06HxPJYpBaFJ1bk5AupZ
+    names:
+      names:
+        m_Keys: 0a000000000000000400000007000000010000000200000005000000080000000300000006000000
+        m_Values:
+        - Rectangle 31
+        - Rectangle 31
+        - 4742c142cbbc4e098948973a62270966
+        - rectangle_31
+        - _rectangle31_1
+        - Rectangle31_1
+        - Rectangle31_1
+        - 
+        - Rectangle 31 4x -1881682822.png
+        - style-Rectangle 31-1881682822
+    tags: c9000000
+    fcuImageType: 1
+    buttonComponent: 0
+    childIndexes: 
+    fcu: {fileID: 0}
+    gameObject: {fileID: 75330358328262865}
+    hash: -1881682822
+    hierarchy:
+    - Index: -1
+      Name: Frame 180
+      Guid: ed1c3ebcdf134bd9886167344dd1ee9d
+    - Index: 10
+      Name: Frame 197
+      Guid: 91a79e8469634d2daf5d01b0f6e4fa2b
+    - Index: 0
+      Name: Group 9
+      Guid: 44b6f4887f944ec89ebb04646e8cd038
+    - Index: 0
+      Name: Group 115
+      Guid: 29dc6a0bee5142f6a81481d91d9b53e3
+    - Index: 0
+      Name: Rectangle 31
+      Guid: 4742c142cbbc4e098948973a62270966
+    rootFrameGO: {fileID: 0}
+    hashDataTree: 
+    parentIndex: 0
+    uguiTransformData:
+      anchorMin: {x: 0, y: 0}
+      anchorMax: {x: 0, y: 0}
+      anchoredPosition: {x: 0, y: 0}
+      sizeDelta: {x: 0, y: 0, z: 0}
+      localRotation: {x: 0, y: 0, z: 0, w: 0}
+      localPosition: {x: 0, y: 0, z: 0}
+      localScale: {x: 0, y: 0, z: 0}
+    graphic:
+      hasFill: 0
+      hasStroke: 0
+      hasSingleColor: 0
+      hasSingleGradient: 0
+      fill:
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      stroke:
+        align: 0
+        weight: 0
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      spriteSingleColor: {r: 0, g: 0, b: 0, a: 0}
+      fillAlpha1: 0
+    rectGameObject: {fileID: 0}
+    spriteSize: {x: 0, y: 0}
+    rect:
+      _position: {x: 0, y: 0}
+      _size: {x: 0, y: 0}
+      _angle: 0
+      _absoluteAngle: 0
+    spritePath: 
+    link: 
+    tagReasons: []
+    downloadableReason: 
+    generativeReason: 
+    downloadAttempsCount: 0
+    isDuplicate: 1
+    isMutual: 0
+    isEmpty: 0
+    needDownload: 1
+    needGenerate: 0
+    forceImage: 0
+    isOverlappedByStroke: 0
+    forceContainer: 0
+    isInsideDownloadable: 1
+    hasFontAsset: 0
+    imageFormat: 0
+    scale: 0
+    maxSpriteSize: {x: 0, y: 0}
+    parentTransformRect: {fileID: 0}
+    parentTransform: {fileID: 0}
+    partOfPrefab: 0
+--- !u!222 &6969892510879357850
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 75330358328262865}
+  m_CullTransparentMesh: 1
+--- !u!114 &2520998659361704690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 75330358328262865}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 41bc1ce8da9e87a4fa340d902394e0df, type: 2}
+  m_Color: {r: 0.8894231, g: 0.8894231, b: 0.8894231, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5121b72252a83544bb560a4a7ef2df92, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1259072046099419650
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1776020475415195923}
+  - component: {fileID: 4011353049157506541}
+  - component: {fileID: 7939762219589516947}
+  - component: {fileID: 7310721313692327667}
+  m_Layer: 5
+  m_Name: ShopList(Unimo)MoneyType
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1776020475415195923
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259072046099419650}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2868282689739333600}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 98.5, y: -359.5}
+  m_SizeDelta: {x: 45, y: 45}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &4011353049157506541
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259072046099419650}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b42570416bdca4697b2749e5bf8c5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debug: 0
+  data:
+    id: 1059:3859
+    projectId: Vn06HxPJYpBaFJ1bk5AupZ
+    names:
+      names:
+        m_Keys: 0a000000000000000400000007000000010000000200000005000000080000000300000006000000
+        m_Values:
+        - Yellow
+        - Yellow
+        - ffebb2a45c6f437a9262cfbbd5234649
+        - yellow
+        - _yellow_2
+        - Yellow_2
+        - Yellow_2
+        - 
+        - Yellow 4x -678305129.png
+        - style-Yellow-678305129
+    tags: 66000000c9000000
+    fcuImageType: 1
+    buttonComponent: 0
+    childIndexes: 
+    fcu: {fileID: 0}
+    gameObject: {fileID: 1259072046099419650}
+    hash: -678305129
+    hierarchy:
+    - Index: -1
+      Name: Frame 180
+      Guid: ed1c3ebcdf134bd9886167344dd1ee9d
+    - Index: 10
+      Name: Frame 197
+      Guid: 91a79e8469634d2daf5d01b0f6e4fa2b
+    - Index: 0
+      Name: Group 9
+      Guid: 44b6f4887f944ec89ebb04646e8cd038
+    - Index: 0
+      Name: Group 115
+      Guid: 29dc6a0bee5142f6a81481d91d9b53e3
+    - Index: 3
+      Name: Yellow
+      Guid: ffebb2a45c6f437a9262cfbbd5234649
+    rootFrameGO: {fileID: 0}
+    hashDataTree: 
+    parentIndex: 0
+    uguiTransformData:
+      anchorMin: {x: 0, y: 0}
+      anchorMax: {x: 0, y: 0}
+      anchoredPosition: {x: 0, y: 0}
+      sizeDelta: {x: 0, y: 0, z: 0}
+      localRotation: {x: 0, y: 0, z: 0, w: 0}
+      localPosition: {x: 0, y: 0, z: 0}
+      localScale: {x: 0, y: 0, z: 0}
+    graphic:
+      hasFill: 0
+      hasStroke: 0
+      hasSingleColor: 0
+      hasSingleGradient: 0
+      fill:
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      stroke:
+        align: 0
+        weight: 0
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      spriteSingleColor: {r: 0, g: 0, b: 0, a: 0}
+      fillAlpha1: 0
+    rectGameObject: {fileID: 0}
+    spriteSize: {x: 0, y: 0}
+    rect:
+      _position: {x: 0, y: 0}
+      _size: {x: 0, y: 0}
+      _angle: 0
+      _absoluteAngle: 0
+    spritePath: 
+    link: 
+    tagReasons: []
+    downloadableReason: 
+    generativeReason: 
+    downloadAttempsCount: 0
+    isDuplicate: 1
+    isMutual: 0
+    isEmpty: 0
+    needDownload: 1
+    needGenerate: 0
+    forceImage: 0
+    isOverlappedByStroke: 0
+    forceContainer: 0
+    isInsideDownloadable: 1
+    hasFontAsset: 0
+    imageFormat: 0
+    scale: 0
+    maxSpriteSize: {x: 0, y: 0}
+    parentTransformRect: {fileID: 0}
+    parentTransform: {fileID: 0}
+    partOfPrefab: 0
+--- !u!222 &7939762219589516947
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259072046099419650}
+  m_CullTransparentMesh: 1
+--- !u!114 &7310721313692327667
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1259072046099419650}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 41bc1ce8da9e87a4fa340d902394e0df, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 37ca940deea86f14aab10d2def6fcfec, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1847459755702258909
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5292368860846866219}
+  - component: {fileID: 5893661645634605194}
+  - component: {fileID: 3884216084504351875}
+  - component: {fileID: 650068455061598522}
+  - component: {fileID: 5099157954460730611}
+  m_Layer: 5
+  m_Name: ShopList(Unimo)Price
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5292368860846866219
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1847459755702258909}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2868282689739333600}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 214, y: -360.5}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5893661645634605194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1847459755702258909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b42570416bdca4697b2749e5bf8c5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debug: 0
+  data:
+    id: 1059:3860
+    projectId: Vn06HxPJYpBaFJ1bk5AupZ
+    names:
+      names:
+        m_Keys: 0a000000000000000400000007000000010000000200000005000000080000000300000006000000
+        m_Values:
+        - 999,999,999
+        - GameObject 10593860
+        - 6e34410d42fa46b3855c0bfb024a6c63
+        - 
+        - _gameObject10593_7
+        - GameObject105938
+        - GameObject105938
+        - TextMeshPro YANGJIN-Medium-28-LeftBottom-Black255
+        - GameObject 10593860
+        - style-GameObject 10593860-1672449956
+    tags: c800000065000000
+    fcuImageType: 0
+    buttonComponent: 0
+    childIndexes: 
+    fcu: {fileID: 0}
+    gameObject: {fileID: 1847459755702258909}
+    hash: 1672449956
+    hierarchy:
+    - Index: -1
+      Name: Frame 180
+      Guid: ed1c3ebcdf134bd9886167344dd1ee9d
+    - Index: 10
+      Name: Frame 197
+      Guid: 91a79e8469634d2daf5d01b0f6e4fa2b
+    - Index: 0
+      Name: Group 9
+      Guid: 44b6f4887f944ec89ebb04646e8cd038
+    - Index: 0
+      Name: Group 115
+      Guid: 29dc6a0bee5142f6a81481d91d9b53e3
+    - Index: 4
+      Name: GameObject 10593860
+      Guid: 6e34410d42fa46b3855c0bfb024a6c63
+    rootFrameGO: {fileID: 0}
+    hashDataTree: 
+    parentIndex: 0
+    uguiTransformData:
+      anchorMin: {x: 0, y: 0}
+      anchorMax: {x: 0, y: 0}
+      anchoredPosition: {x: 0, y: 0}
+      sizeDelta: {x: 0, y: 0, z: 0}
+      localRotation: {x: 0, y: 0, z: 0, w: 0}
+      localPosition: {x: 0, y: 0, z: 0}
+      localScale: {x: 0, y: 0, z: 0}
+    graphic:
+      hasFill: 0
+      hasStroke: 0
+      hasSingleColor: 0
+      hasSingleGradient: 0
+      fill:
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      stroke:
+        align: 0
+        weight: 0
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      spriteSingleColor: {r: 0, g: 0, b: 0, a: 0}
+      fillAlpha1: 0
+    rectGameObject: {fileID: 0}
+    spriteSize: {x: 0, y: 0}
+    rect:
+      _position: {x: 0, y: 0}
+      _size: {x: 0, y: 0}
+      _angle: 0
+      _absoluteAngle: 0
+    spritePath: 
+    link: 
+    tagReasons: []
+    downloadableReason: 
+    generativeReason: 
+    downloadAttempsCount: 0
+    isDuplicate: 1
+    isMutual: 0
+    isEmpty: 0
+    needDownload: 0
+    needGenerate: 0
+    forceImage: 0
+    isOverlappedByStroke: 0
+    forceContainer: 0
+    isInsideDownloadable: 0
+    hasFontAsset: 0
+    imageFormat: 0
+    scale: 0
+    maxSpriteSize: {x: 0, y: 0}
+    parentTransformRect: {fileID: 0}
+    parentTransform: {fileID: 0}
+    partOfPrefab: 0
+--- !u!114 &3884216084504351875
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1847459755702258909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!222 &650068455061598522
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1847459755702258909}
+  m_CullTransparentMesh: 1
+--- !u!114 &5099157954460730611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1847459755702258909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 999,999,999
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 934dd59316476cc4bb5148676dd507ef, type: 2}
+  m_sharedMaterial: {fileID: 6497309756745478032, guid: 934dd59316476cc4bb5148676dd507ef,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4280492835
+  m_fontColor: {r: 0.13725491, g: 0.13725491, b: 0.13725491, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 1
+  m_fontSizeMax: 28
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 1024
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 28.34
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3266456279481873554
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3094603065491638725}
+  - component: {fileID: 2048137538944892358}
+  - component: {fileID: 4670915792333421588}
+  m_Layer: 5
+  m_Name: ShopList(Unimo)Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3094603065491638725
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3266456279481873554}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 443881760089758774}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 278, y: 278}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2048137538944892358
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3266456279481873554}
+  m_CullTransparentMesh: 1
+--- !u!114 &4670915792333421588
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3266456279481873554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3617818226408430869
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 443881760089758774}
+  - component: {fileID: 8239162599232123729}
+  - component: {fileID: 7269895924583769621}
+  - component: {fileID: 2552365923641003215}
+  m_Layer: 5
+  m_Name: ShopList(Unimo)BG2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &443881760089758774
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3617818226408430869}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3094603065491638725}
+  m_Father: {fileID: 2868282689739333600}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 190, y: -191}
+  m_SizeDelta: {x: 278, y: 278}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8239162599232123729
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3617818226408430869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b42570416bdca4697b2749e5bf8c5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debug: 0
+  data:
+    id: 1059:3765
+    projectId: Vn06HxPJYpBaFJ1bk5AupZ
+    names:
+      names:
+        m_Keys: 0a000000000000000400000007000000010000000200000005000000080000000300000006000000
+        m_Values:
+        - Rectangle 143
+        - Rectangle 143
+        - 63cf9f55460a486ba33f85e43ddc8631
+        - rectangle_143
+        - _rectangle143
+        - Rectangle143
+        - Rectangle143
+        - 
+        - Rectangle 143
+        - style-Rectangle 143-1711544546
+    tags: c9000000
+    fcuImageType: 2
+    buttonComponent: 0
+    childIndexes: 
+    fcu: {fileID: 0}
+    gameObject: {fileID: 3617818226408430869}
+    hash: 1711544546
+    hierarchy:
+    - Index: -1
+      Name: Frame 180
+      Guid: ed1c3ebcdf134bd9886167344dd1ee9d
+    - Index: 10
+      Name: Frame 197
+      Guid: 91a79e8469634d2daf5d01b0f6e4fa2b
+    - Index: 0
+      Name: Group 9
+      Guid: 44b6f4887f944ec89ebb04646e8cd038
+    - Index: 0
+      Name: Group 115
+      Guid: 29dc6a0bee5142f6a81481d91d9b53e3
+    - Index: 1
+      Name: Rectangle 143
+      Guid: 63cf9f55460a486ba33f85e43ddc8631
+    rootFrameGO: {fileID: 0}
+    hashDataTree: 
+    parentIndex: 0
+    uguiTransformData:
+      anchorMin: {x: 0, y: 0}
+      anchorMax: {x: 0, y: 0}
+      anchoredPosition: {x: 0, y: 0}
+      sizeDelta: {x: 0, y: 0, z: 0}
+      localRotation: {x: 0, y: 0, z: 0, w: 0}
+      localPosition: {x: 0, y: 0, z: 0}
+      localScale: {x: 0, y: 0, z: 0}
+    graphic:
+      hasFill: 0
+      hasStroke: 0
+      hasSingleColor: 0
+      hasSingleGradient: 0
+      fill:
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      stroke:
+        align: 0
+        weight: 0
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      spriteSingleColor: {r: 0, g: 0, b: 0, a: 0}
+      fillAlpha1: 0
+    rectGameObject: {fileID: 0}
+    spriteSize: {x: 0, y: 0}
+    rect:
+      _position: {x: 0, y: 0}
+      _size: {x: 0, y: 0}
+      _angle: 0
+      _absoluteAngle: 0
+    spritePath: 
+    link: 
+    tagReasons: []
+    downloadableReason: 
+    generativeReason: 
+    downloadAttempsCount: 0
+    isDuplicate: 1
+    isMutual: 0
+    isEmpty: 0
+    needDownload: 0
+    needGenerate: 0
+    forceImage: 0
+    isOverlappedByStroke: 0
+    forceContainer: 0
+    isInsideDownloadable: 0
+    hasFontAsset: 0
+    imageFormat: 0
+    scale: 0
+    maxSpriteSize: {x: 0, y: 0}
+    parentTransformRect: {fileID: 0}
+    parentTransform: {fileID: 0}
+    partOfPrefab: 0
+--- !u!222 &7269895924583769621
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3617818226408430869}
+  m_CullTransparentMesh: 1
+--- !u!114 &2552365923641003215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3617818226408430869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 41bc1ce8da9e87a4fa340d902394e0df, type: 2}
+  m_Color: {r: 1, g: 0.6570511, b: 0.6570511, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4226686437539964634
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2868282689739333600}
+  - component: {fileID: 3361064993690510581}
+  - component: {fileID: 7490808812642202199}
+  - component: {fileID: 507792839905570533}
+  m_Layer: 5
+  m_Name: ShopList(Unimo)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2868282689739333600
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4226686437539964634}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6444236054497172120}
+  - {fileID: 443881760089758774}
+  - {fileID: 7275778302366066120}
+  - {fileID: 1776020475415195923}
+  - {fileID: 5292368860846866219}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 380, y: 450}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3361064993690510581
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4226686437539964634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b42570416bdca4697b2749e5bf8c5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debug: 0
+  data:
+    id: 1059:3763
+    projectId: Vn06HxPJYpBaFJ1bk5AupZ
+    names:
+      names:
+        m_Keys: 0a000000000000000400000007000000010000000200000005000000080000000300000006000000
+        m_Values:
+        - Group 115
+        - Group 115
+        - 29dc6a0bee5142f6a81481d91d9b53e3
+        - group_115
+        - _group115
+        - Group115
+        - Group115
+        - 
+        - Group 115
+        - style-Group 115-531276359
+    tags: 01000000
+    fcuImageType: 0
+    buttonComponent: 0
+    childIndexes: 4100000042000000430000004400000045000000
+    fcu: {fileID: 0}
+    gameObject: {fileID: 4226686437539964634}
+    hash: -531276359
+    hierarchy:
+    - Index: -1
+      Name: Frame 180
+      Guid: ed1c3ebcdf134bd9886167344dd1ee9d
+    - Index: 10
+      Name: Frame 197
+      Guid: 91a79e8469634d2daf5d01b0f6e4fa2b
+    - Index: 0
+      Name: Group 9
+      Guid: 44b6f4887f944ec89ebb04646e8cd038
+    - Index: 0
+      Name: Group 115
+      Guid: 29dc6a0bee5142f6a81481d91d9b53e3
+    rootFrameGO: {fileID: 0}
+    hashDataTree: 
+    parentIndex: 0
+    uguiTransformData:
+      anchorMin: {x: 0, y: 0}
+      anchorMax: {x: 0, y: 0}
+      anchoredPosition: {x: 0, y: 0}
+      sizeDelta: {x: 0, y: 0, z: 0}
+      localRotation: {x: 0, y: 0, z: 0, w: 0}
+      localPosition: {x: 0, y: 0, z: 0}
+      localScale: {x: 0, y: 0, z: 0}
+    graphic:
+      hasFill: 0
+      hasStroke: 0
+      hasSingleColor: 0
+      hasSingleGradient: 0
+      fill:
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      stroke:
+        align: 0
+        weight: 0
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      spriteSingleColor: {r: 0, g: 0, b: 0, a: 0}
+      fillAlpha1: 0
+    rectGameObject: {fileID: 0}
+    spriteSize: {x: 0, y: 0}
+    rect:
+      _position: {x: 0, y: 0}
+      _size: {x: 0, y: 0}
+      _angle: 0
+      _absoluteAngle: 0
+    spritePath: 
+    link: 
+    tagReasons:
+    - children not empty
+    downloadableReason: 
+    generativeReason: 
+    downloadAttempsCount: 0
+    isDuplicate: 1
+    isMutual: 0
+    isEmpty: 0
+    needDownload: 0
+    needGenerate: 0
+    forceImage: 0
+    isOverlappedByStroke: 0
+    forceContainer: 0
+    isInsideDownloadable: 0
+    hasFontAsset: 0
+    imageFormat: 0
+    scale: 0
+    maxSpriteSize: {x: 0, y: 0}
+    parentTransformRect: {fileID: 0}
+    parentTransform: {fileID: 0}
+    partOfPrefab: 0
+--- !u!114 &7490808812642202199
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4226686437539964634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af697d6bfd90684438f5dfe4b213d39e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemType: 1
+  _itemName: {fileID: 4888566950833713472}
+  _itemIcon: {fileID: 4670915792333421588}
+  _currencyImage: {fileID: 7310721313692327667}
+  _priceText: {fileID: 5099157954460730611}
+  _buyButtonText: {fileID: 0}
+  _buyButton: {fileID: 507792839905570533}
+  _gameMoneySprite: {fileID: 21300000, guid: 37ca940deea86f14aab10d2def6fcfec, type: 3}
+  _cashSprite: {fileID: 21300000, guid: d46471f8ea6780240a8149a1432a41a8, type: 3}
+--- !u!114 &507792839905570533
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4226686437539964634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2520998659361704690}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &8807392156226058120
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7275778302366066120}
+  - component: {fileID: 1347447429897907109}
+  - component: {fileID: 5064113815959313866}
+  - component: {fileID: 4907829797719709911}
+  - component: {fileID: 4888566950833713472}
+  m_Layer: 5
+  m_Name: ShopList(Unimo)Name
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7275778302366066120
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8807392156226058120}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2868282689739333600}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 190, y: -406.5}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1347447429897907109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8807392156226058120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b42570416bdca4697b2749e5bf8c5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debug: 0
+  data:
+    id: 1059:3766
+    projectId: Vn06HxPJYpBaFJ1bk5AupZ
+    names:
+      names:
+        m_Keys: 0a000000000000000400000007000000010000000200000005000000080000000300000006000000
+        m_Values:
+        - "\uC774\uB984\uC774\uB984\uC774\uB984\uC774\uB984\uC774\uB984"
+        - GameObject 10593766
+        - 3b7986f7c89e4e00b138de3e848f7559
+        - 
+        - _gameObject10593_5
+        - GameObject105937_2
+        - GameObject105937_2
+        - TextMeshPro YANGJIN-Medium-36-CenterBottom-Black255
+        - GameObject 10593766
+        - style-GameObject 10593766-1198722305
+    tags: c800000065000000
+    fcuImageType: 0
+    buttonComponent: 0
+    childIndexes: 
+    fcu: {fileID: 0}
+    gameObject: {fileID: 8807392156226058120}
+    hash: -1198722305
+    hierarchy:
+    - Index: -1
+      Name: Frame 180
+      Guid: ed1c3ebcdf134bd9886167344dd1ee9d
+    - Index: 10
+      Name: Frame 197
+      Guid: 91a79e8469634d2daf5d01b0f6e4fa2b
+    - Index: 0
+      Name: Group 9
+      Guid: 44b6f4887f944ec89ebb04646e8cd038
+    - Index: 0
+      Name: Group 115
+      Guid: 29dc6a0bee5142f6a81481d91d9b53e3
+    - Index: 2
+      Name: GameObject 10593766
+      Guid: 3b7986f7c89e4e00b138de3e848f7559
+    rootFrameGO: {fileID: 0}
+    hashDataTree: 
+    parentIndex: 0
+    uguiTransformData:
+      anchorMin: {x: 0, y: 0}
+      anchorMax: {x: 0, y: 0}
+      anchoredPosition: {x: 0, y: 0}
+      sizeDelta: {x: 0, y: 0, z: 0}
+      localRotation: {x: 0, y: 0, z: 0, w: 0}
+      localPosition: {x: 0, y: 0, z: 0}
+      localScale: {x: 0, y: 0, z: 0}
+    graphic:
+      hasFill: 0
+      hasStroke: 0
+      hasSingleColor: 0
+      hasSingleGradient: 0
+      fill:
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      stroke:
+        align: 0
+        weight: 0
+        hasSolid: 0
+        hasGradient: 0
+        singleColor: {r: 0, g: 0, b: 0, a: 0}
+      spriteSingleColor: {r: 0, g: 0, b: 0, a: 0}
+      fillAlpha1: 0
+    rectGameObject: {fileID: 0}
+    spriteSize: {x: 0, y: 0}
+    rect:
+      _position: {x: 0, y: 0}
+      _size: {x: 0, y: 0}
+      _angle: 0
+      _absoluteAngle: 0
+    spritePath: 
+    link: 
+    tagReasons: []
+    downloadableReason: 
+    generativeReason: 
+    downloadAttempsCount: 0
+    isDuplicate: 1
+    isMutual: 0
+    isEmpty: 0
+    needDownload: 0
+    needGenerate: 0
+    forceImage: 0
+    isOverlappedByStroke: 0
+    forceContainer: 0
+    isInsideDownloadable: 0
+    hasFontAsset: 0
+    imageFormat: 0
+    scale: 0
+    maxSpriteSize: {x: 0, y: 0}
+    parentTransformRect: {fileID: 0}
+    parentTransform: {fileID: 0}
+    partOfPrefab: 0
+--- !u!114 &5064113815959313866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8807392156226058120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!222 &4907829797719709911
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8807392156226058120}
+  m_CullTransparentMesh: 1
+--- !u!114 &4888566950833713472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8807392156226058120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uC774\uB984\uC774\uB984\uC774\uB984\uC774\uB984\uC774\uB984"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 934dd59316476cc4bb5148676dd507ef, type: 2}
+  m_sharedMaterial: {fileID: 6497309756745478032, guid: 934dd59316476cc4bb5148676dd507ef,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4280492835
+  m_fontColor: {r: 0.13725491, g: 0.13725491, b: 0.13725491, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 1
+  m_fontSizeMax: 36
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 1024
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 99.34
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/Assets/00_WorkSpace/NTJ/ShopList(Unimo).prefab.meta
+++ b/Assets/00_WorkSpace/NTJ/ShopList(Unimo).prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0e1379ffadf9e1447a1671d6855e8a5c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_WorkSpace/NTJ/_buyButtonPrefab.prefab
+++ b/Assets/00_WorkSpace/NTJ/_buyButtonPrefab.prefab
@@ -1,0 +1,104 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &158884780826799796
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6320950441185286308}
+  - component: {fileID: 1756946873774891113}
+  - component: {fileID: 8037129741147524103}
+  m_Layer: 5
+  m_Name: _buyButtonPrefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6320950441185286308
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 158884780826799796}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1756946873774891113
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 158884780826799796}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af697d6bfd90684438f5dfe4b213d39e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemType: 0
+  _itemName: {fileID: 0}
+  _itemIcon: {fileID: 0}
+  _currencyImage: {fileID: 0}
+  _priceText: {fileID: 0}
+  _buyButtonText: {fileID: 0}
+  _buyButton: {fileID: 0}
+  _gameMoneySprite: {fileID: 0}
+  _cashSprite: {fileID: 0}
+--- !u!114 &8037129741147524103
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 158884780826799796}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/00_WorkSpace/NTJ/_buyButtonPrefab.prefab.meta
+++ b/Assets/00_WorkSpace/NTJ/_buyButtonPrefab.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0d74eeafc258bf340a0416f34e9dd5f5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UnimoCharacterSO.cs
+++ b/Assets/Scripts/UnimoCharacterSO.cs
@@ -16,6 +16,10 @@ public class UnimoCharacterSO : ScriptableObject
     [Tooltip("테이블의 '캐릭터 스프라이트'")]
     public Sprite characterSprite;
 
+    [Tooltip("재화 타입 (예: GameMoney, Cash)")]
+
+    public Sprite currencyType;
+
     [TextArea]
     [Tooltip("테이블의 '캐릭터 설명'")]
     public string characterInfo;

--- a/Assets/Scripts/UnimoKartSO.cs
+++ b/Assets/Scripts/UnimoKartSO.cs
@@ -18,6 +18,10 @@ public class UnimoKartSO : ScriptableObject
     [Tooltip("차량 스프라이트")]
     public Sprite kartSprite;
 
+    [Header("Shop")]
+    [Tooltip("재화 타입에 해당하는 아이콘")]
+    public Sprite currencyType;
+
 
     [TextArea]
     [Tooltip("차량 설명")]


### PR DESCRIPTION
## 🧩 개요
- 이번 PR에서 변경된 핵심 내용을 간단히 적어주세요.
- 관련 이슈: Close #

## 📁 변경 사항 체크리스트

- [ ] C# 스크립트 추가/수정
- [ ] 프리팹 변경
- [ ] 씬(.unity) 파일 변경
- [ ] 애니메이션/사운드 리소스 변경
- [ ] ScriptableObject 변경
- [ ] 기타 리소스 또는 설정 변경

## ✅ 확인 사항

- [ ] Unity 에디터에서 정상 동작 확인
- [ ] 관련 기능 플레이 테스트 완료
- [ ] 에러/경고 없음
- [ ] 변경된 파일이 Git LFS 대상인지 확인 (필요시)
- [ ] 충돌 방지를 위해 최신 develop/main 브랜치에서 작업

## 🧪 테스트 내역

- [ ] 새 기능 직접 실행 확인
- [ ] 씬 변경 시, 기존 오브젝트와 충돌 없음
- [ ] 멀티플레이/네트워크 관련 기능 확인 (해당 시)
- [ ] (선택) 커스텀 유닛/에디터 테스트 포함

## 📝 기타
