### PR TITLE
[feat]: 카트/플레이어 레이싱 상황 업데이트 및 InGameManager 개선, 아이템 박스 테스트 기능 추가

### DIFF
--- a/Assets/00_WorkSpace/YSJ/Scripts/DollyCart/DollyCartSync.cs
+++ b/Assets/00_WorkSpace/YSJ/Scripts/DollyCart/DollyCartSync.cs
@@ -9,7 +9,7 @@ public class DollyCartSync : MonoBehaviourPun, IPunObservable
     [SerializeField, Min(0.1f)] private float _fixedCPUpdateCycleTime = 2.0f;
 
     private bool _isSetup = false;
-
+    private bool _fixedableUpdateCP = false;
     private PlayerRaceData _data;
     private PlayerManager _pm;
     private float _currentCycleTime = 0.0f;
@@ -17,11 +17,18 @@ public class DollyCartSync : MonoBehaviourPun, IPunObservable
     public bool IsSetup => _isSetup;
     #endregion
 
-    private void OnDisable()
+    public void Update()
     {
         if (!_isSetup) return;
+        if (!_data.View.IsMine) return;
+        if (!_fixedableUpdateCP) return;
 
-        _data.OnAfterRaceSetupAction -= AfterPlayerRaceSetupChangeRacableCP;
+        _currentCycleTime += Time.deltaTime;
+        if (_currentCycleTime > _fixedCPUpdateCycleTime)
+        {
+            _currentCycleTime -= _fixedCPUpdateCycleTime;
+            FixedCPUpdate();
+        }
     }
 
     public void Setup(PlayerRaceData data)
@@ -35,12 +42,18 @@ public class DollyCartSync : MonoBehaviourPun, IPunObservable
         _data = data;
         _pm = PlayerManager.Instance;
 
-        _data.OnAfterRaceSetupAction -= AfterPlayerRaceSetupChangeRacableCP;
-        _data.OnAfterRaceSetupAction += AfterPlayerRaceSetupChangeRacableCP;
+        var pm = PlayerManager.Instance;
+        pm.SetPlayerCPRaceCurrentNorm(_data.Lap + _data.Norm);
+
+        var iGM = InGameManager.Instance;
+        iGM.OnStateChanged -= OnRaceStateEnter;
+        iGM.OnStateChanged += OnRaceStateEnter;
+
         _currentCycleTime = 0.0f;
         _isSetup = true;
     }
 
+    #region Photon Network
     // 동기화를 받아야 되는 카트에 필요
     public void OnPhotonSerializeView(PhotonStream stream, PhotonMessageInfo info)
     {
@@ -57,7 +70,6 @@ public class DollyCartSync : MonoBehaviourPun, IPunObservable
             Receive(stream, info);
         }
     }
-
     // 보내기
     private void Send(PhotonStream stream, PhotonMessageInfo info)
     {
@@ -71,7 +83,6 @@ public class DollyCartSync : MonoBehaviourPun, IPunObservable
         stream.SendNext(_data.IsMovable);
         stream.SendNext(_data.IsItemUsable);
     }
-
     // 받기
     private void Receive(PhotonStream stream, PhotonMessageInfo info)
     {
@@ -94,33 +105,19 @@ public class DollyCartSync : MonoBehaviourPun, IPunObservable
         // _controller.SyncReceive(recvNorm, recvLap, recvSpeed);
     }
 
-    private void AfterPlayerRaceSetupChangeRacableCP()
-    {
-        if (_isSetup) return;
+    #endregion
 
-        var pm = PlayerManager.Instance;
-        if (_data != null)
-        {
-            pm.SetPlayerCPRaceLoaded(_data.IsSetups);
-            pm.SetPlayerCPRaceCurrentNorm(_data.Lap + _data.Norm);
-        }
+    #region Action
+    private void OnRaceStateEnter(RaceState state)
+    {
+        _fixedableUpdateCP = (state == RaceState.Racing);
     }
+
+    #endregion
 
     private void FixedCPUpdate()
     {
         _pm?.SetPlayerCPRaceCurrentNorm(_data.Lap + _data.Norm);
     }
 
-    public void Update()
-    {
-        if (!_isSetup) return;
-        if (!_data.View.IsMine) return;
-
-        _currentCycleTime += Time.deltaTime;
-        if (_currentCycleTime > _fixedCPUpdateCycleTime)
-        {
-            _currentCycleTime -= _fixedCPUpdateCycleTime;
-            FixedCPUpdate();
-        }
-    }
 }

--- a/Assets/00_WorkSpace/YSJ/Scripts/Item/ItemBox.cs
+++ b/Assets/00_WorkSpace/YSJ/Scripts/Item/ItemBox.cs
@@ -1,4 +1,5 @@
-﻿using Photon.Pun;
+﻿using DA_Assets.FCU;
+using Photon.Pun;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -22,7 +23,7 @@ public class ItemBox : MonoBehaviour
 
     [Header("Visual Config")]
     [SerializeField] private bool _isSpawnVisualBoxBody;            // 시작적 오브젝트 생성 여부
-    [SerializeField] private GameObject _spawnableVisualBoxBody;    // 시각적 오브젝트
+    [SerializeField] private GameObject _spawnableVisualBoxBodyGO;    // 시각적 오브젝트
     [SerializeField] private GameObject _boxBodySpawnPoint;         // 실적용 바디를 스폰할 포인트
 
     [Header("Sound Config")]
@@ -52,6 +53,21 @@ public class ItemBox : MonoBehaviour
         _firtSpawnTime = PhotonNetwork.Time;
         if (_isSpawnVisualBoxBody)
         {
+            if (_boxBodySpawnPoint == null)
+            {
+                this.PrintLog($"{name}: _boxBodySpawnPoint가 비어있어. _boxBodySpawnPoint를 자동 생성합니다.");
+                _boxBodySpawnPoint = GameObject.Instantiate(new GameObject("BodyPoint"), this.gameObject.transform);
+            }
+
+            if(_spawnableVisualBoxBodyGO)
+            {
+                _boxBody = GameObject.Instantiate(_spawnableVisualBoxBodyGO, _boxBodySpawnPoint.transform);
+                _boxBody.transform.localPosition = Vector3.zero;
+                _boxBody.transform.localRotation = Quaternion.identity;
+
+                this.PrintLog($"{name}: _spawnableVisualBoxBodyGO > PhotonNetwork.Instantiate 생성합니다.");
+            }
+
             if (_boxBody == null)
                 this.PrintLog($"{name}: _boxBody가 비어있어. 비주얼이 보이지 않을 수 있습니다.");
         }

--- a/Assets/00_WorkSpace/YSJ/Scripts/Manager/InGameManager.cs
+++ b/Assets/00_WorkSpace/YSJ/Scripts/Manager/InGameManager.cs
@@ -44,6 +44,8 @@ public class InGameManager : SimpleSingletonPun<InGameManager>
     private MapCycleManager _mapCycleManager;
     private MapAssetLoader _mapAssetLoader;
 
+    private List<PlayerRaceData> _playerRaceDatas = new();
+
     // private Util Value
     private bool IsMasterClient => PhotonNetwork.IsMasterClient;
     private Room CurrentRoom => PhotonNetwork.CurrentRoom;
@@ -64,6 +66,8 @@ public class InGameManager : SimpleSingletonPun<InGameManager>
     public double RaceStartTime => _raceStartTime;
 
     public int RaceEndLapCount => _laps;
+
+    private List<PlayerRaceData> PlayerRaceDatas => _playerRaceDatas;
 
     // public Action
     /// <summary>
@@ -531,6 +535,84 @@ public class InGameManager : SimpleSingletonPun<InGameManager>
         PhotonNetwork.LoadLevel(1);
         PhotonNetwork.LeaveRoom();
     }
+
+    // Util
+    public void RegisterPlayer(PlayerRaceData raceData)
+    {
+        if (raceData == null)
+        {
+            this.PrintLog("RegisterPlayer 실패: raceData가 null", LogType.Warning);
+            return;
+        }
+
+        // 기존에 같은 객체나 같은 ViewID가 있으면 제거(중복 방지) + 널 정리
+        int before = _playerRaceDatas.Count;
+        _playerRaceDatas.RemoveAll(p =>
+            p == null ||
+            p.Equals(null) ||                 // 파괴된 Unity 객체 대비
+            p == raceData ||
+            (p.View != null && raceData.View != null && p.View.ViewID == raceData.View.ViewID)
+        );
+
+        _playerRaceDatas.Add(raceData);
+
+        // 결정적 순서 유지(네트워크 재현성을 위해 ViewID 기준 정렬)
+        _playerRaceDatas.Sort((a, b) =>
+        {
+            int av = (a != null && a.View != null) ? a.View.ViewID : int.MaxValue;
+            int bv = (b != null && b.View != null) ? b.View.ViewID : int.MaxValue;
+            return av.CompareTo(bv);
+        });
+
+        this.PrintLog($"RegisterPlayer: {raceData.name} (중복 {before - _playerRaceDatas.Count + 1}개 제거 포함) / 총 인원: {_playerRaceDatas.Count}");
+
+        // 마스터면, 로딩 단계였을 때 조건 재검사(전원 로드 완료 여부)
+        if (IsMasterClient && CurrentRoom != null && _currentRaceState == RaceState.LoadPlayers)
+        {
+            Check_Players_RaceKartLoaded();
+        }
+    }
+
+    public void UnregisterPlayer(PlayerRaceData raceData)
+    {
+        if (raceData == null)
+        {
+            this.PrintLog("UnregisterPlayer 실패: raceData가 null", LogType.Warning);
+            return;
+        }
+
+        int removed = _playerRaceDatas.RemoveAll(p =>
+            p == null ||
+            p.Equals(null) ||
+            p == raceData ||
+            (p.View != null && raceData.View != null && p.View.ViewID == raceData.View.ViewID)
+        );
+
+        this.PrintLog($"UnregisterPlayer: {raceData.name} / 제거 {removed}개 / 총 인원: {_playerRaceDatas.Count}");
+
+        // 마스터면, 게임 진행 중 이탈 케이스에 대한 간단한 처리
+        if (IsMasterClient && CurrentRoom != null)
+        {
+            switch (_currentRaceState)
+            {
+                case RaceState.LoadPlayers:
+                    // 로딩 단계에서 인원 변동 시 다시 조건 확인
+                    Check_Players_RaceKartLoaded();
+                    break;
+
+                case RaceState.Racing:
+                    // 모두 나가면 비정상 종료로 전환
+                    if (_playerRaceDatas.Count <= 0)
+                    {
+                        this.PrintLog("모든 플레이어 이탈 감지 → FailedGame 전환");
+                        SendRaceState(RaceState.FailedGame);
+                    }
+                    break;
+            }
+        }
+    }
+
+
 
     private void PrintLog(string printLogString)
     {

--- a/Assets/00_WorkSpace/YSJ/Scripts/Manager/InGameManager.cs
+++ b/Assets/00_WorkSpace/YSJ/Scripts/Manager/InGameManager.cs
@@ -53,7 +53,7 @@ public class InGameManager : SimpleSingletonPun<InGameManager>
 
     private SceneID GetPlayerSceneID(Player p) => PhotonNetworkCustomProperties.GetPlayerProp<SceneID>(p, PlayerKey.CurrentScene);
     private bool GetPlayerRaceLoaded(Player p) => PhotonNetworkCustomProperties.GetPlayerProp<bool>(p, PlayerKey.RaceLoaded);
-    private bool GetPlayerRaceFinished(Player p) => PhotonNetworkCustomProperties.GetPlayerProp<bool>(p, PlayerKey.RaceIsFinished);
+    private bool GetPlayerRaceFinished(Player p) => PhotonNetworkCustomProperties.GetPlayerProp<bool>(p, PlayerKey.RaceIsFinished, false);
     private float GetPlayerRaceFinishTime(Player p) => PhotonNetworkCustomProperties.GetPlayerProp<float>(p, PlayerKey.RaceFinishedTime);
 
     // public Value
@@ -426,13 +426,17 @@ public class InGameManager : SimpleSingletonPun<InGameManager>
         if (!IsMasterClient || CurrentRoom == null) return;
 
         this.PrintLog($"Action >>>>>>>>>>>>> Check_Players_RaceKartLoaded {CurrentRoom.Players.Values.Count}");
+
+        if (_playablePlayersCount != CurrentRoom.Players.Values.Count)
+        {
+            this.PrintLog($"플레이 가능 인원 수가 맞지 않습니다. => [인원 수 상황: {CurrentRoom.Players.Values.Count} / {_playablePlayersCount}]");
+            return;
+        }
         foreach (var p in CurrentRoom.Players.Values)
         {
-            PhotonNetworkCustomProperties.PrintPlayerCustomProperties(p);
+            this.PrintLog(PhotonNetworkCustomProperties.PrintPlayerCustomProperties(p));
             var raceLoaded = GetPlayerRaceLoaded(p);
             if (!raceLoaded) return;
-
-            PhotonNetworkCustomProperties.PrintPlayerCustomProperties(p);
         }
 
         this.PrintLog($"Complete Action >>>>>>>>>>>>> Check_Players_RaceKartLoaded {CurrentRoom.Players.Values.Count}");
@@ -448,15 +452,14 @@ public class InGameManager : SimpleSingletonPun<InGameManager>
         float finishTime = float.MaxValue;
         foreach (var p in CurrentRoom.Players.Values)
         {
-            PhotonNetworkCustomProperties.PrintPlayerCustomProperties(p);
             var finished = GetPlayerRaceFinished(p);
             var playerFinishTime = GetPlayerRaceFinishTime(p);
 
+           this.PrintLog(PhotonNetworkCustomProperties.PrintPlayerCustomProperties(p));
+            this.PrintLog($"Checking >>>>>>>>>>>>> Check_Players_IsRaceFinished [({finishTime} > {playerFinishTime}) => {finishTime > playerFinishTime} / finished => {finished}]");
             if (finishTime > playerFinishTime)
                 finishTime = playerFinishTime;
             if (!finished) return;
-
-            PhotonNetworkCustomProperties.PrintPlayerCustomProperties(p);
         }
 
         PhotonNetworkCustomProperties.RaceFinishSetting(finishTime, _finishSeconds);

--- a/Assets/00_WorkSpace/YSJ/Scripts/PhotonNetworkCustomProperties.cs
+++ b/Assets/00_WorkSpace/YSJ/Scripts/PhotonNetworkCustomProperties.cs
@@ -689,7 +689,7 @@ public static class PhotonNetworkCustomProperties
                 // PHOTON - Race
                 { PlayerKey.RaceCurrentNorm,          0.0f          },
                 { PlayerKey.RaceLoaded,               false         },
-                { PlayerKey.RaceIsFinished,           -1            },
+                { PlayerKey.RaceIsFinished,           false         },
                 { PlayerKey.RaceFinishedTime,         -1            },
                 // { PlayerKey.CurrentScene,             sceneId       },
             }
@@ -716,7 +716,7 @@ public static class PhotonNetworkCustomProperties
                 // PHOTON - Race
                 { PlayerKey.RaceCurrentNorm,          0.0f          },
                 { PlayerKey.RaceLoaded,               false         },
-                { PlayerKey.RaceIsFinished,           -1            },
+                { PlayerKey.RaceIsFinished,           false         },
                 { PlayerKey.RaceFinishedTime,         -1            },
                 // { PlayerKey.CurrentScene,             -1            },
             }
@@ -743,7 +743,7 @@ public static class PhotonNetworkCustomProperties
                 // PHOTON - Race
                 // { PlayerKey.RaceCurrentNorm,          0.0f          },
                 { PlayerKey.RaceLoaded,               false         },
-                { PlayerKey.RaceIsFinished,           -1            },
+                { PlayerKey.RaceIsFinished,           false         },
                 { PlayerKey.RaceFinishedTime,         -1            },
                 // { PlayerKey.CurrentScene,             -1            },
             }
@@ -770,7 +770,7 @@ public static class PhotonNetworkCustomProperties
                 // PHOTON - Race
                 // { PlayerKey.RaceCurrentNorm,          0.0f          },
                 { PlayerKey.RaceLoaded,               true          },
-                { PlayerKey.RaceIsFinished,           -1            },
+                { PlayerKey.RaceIsFinished,           false         },
                 { PlayerKey.RaceFinishedTime,         -1            },
                 // { PlayerKey.CurrentScene,             -1            },
             }

--- a/Assets/00_WorkSpace/YSJ/Scripts/Player/ItemInventory.cs
+++ b/Assets/00_WorkSpace/YSJ/Scripts/Player/ItemInventory.cs
@@ -95,7 +95,21 @@ public class ItemInventory : MonoBehaviour
         _items[nullIndex] = itemSO;
         this.PrintLog($"아이템을 저장합니다.[저장 인덱스: {nullIndex} / 저장 아이템 {itemSO.name}_{itemSO.itemID}]");
     }
+            if (_delaySaveItemList.Count <= 0)
+            {
+                this.PrintLog($"지연 아이템 저장에 사용될 아이템들 유실 되어, 지연 아이템 저장을 진행 할 수 없습니다.");
+                return;
+            }
 
+            // 데이터 받고도 유실 시, 처리
+            if (delaySaveItem == null)
+            {
+                this.PrintLog($"Delay Save Item 데이터가 유실 되어서 습니다. 기존에 진행하려고 했던 지연 아이템 저장 기능을 사용할 수 없습니다. > 필요 없는 데이터들을 정리합니다.");
+                return;
+            }
+
+            _items[saveIndex] = delaySaveItem;
+            this.PrintLog($"지연 아이템 저장 완료. 되었습니다.(=> 지연 저장 아이템 정보: {delaySaveItem.name}_{delaySaveItem.itemID})");
     /// <summary>
     /// 보유 아이템, 인텍스로 제거
     /// </summary>

--- a/Assets/00_WorkSpace/YSJ/Scripts/Player/PlayerRaceData.cs
+++ b/Assets/00_WorkSpace/YSJ/Scripts/Player/PlayerRaceData.cs
@@ -128,6 +128,16 @@ public class PlayerRaceData : MonoBehaviour, IPunInstantiateMagicCallback
         _isEndRace = false;
     }
 
+    private void OnDisable()
+    {
+        _inGM?.UnregisterPlayer(this);
+    }
+
+    private void OnDestroy()
+    {
+        _inGM?.UnregisterPlayer(this);
+    }
+
     #endregion
 
     #region Setup
@@ -268,6 +278,8 @@ public class PlayerRaceData : MonoBehaviour, IPunInstantiateMagicCallback
             // 레이싱 끝
             _inGM.OnRaceState_Finish -= OnPlayRaceExit;
             _inGM.OnRaceState_Finish += OnPlayRaceExit;
+
+            _inGM.RegisterPlayer(this);
         }
 
         this.PrintLog("GameManagerSetup 진행 완료");
@@ -612,7 +624,7 @@ public class PlayerRaceData : MonoBehaviour, IPunInstantiateMagicCallback
     [SerializeField] private SynergyItemRule[] synergyRules;
 
     private readonly System.Collections.Generic.Dictionary<string, int> synergyCounts
-        = new System.Collections.Generic.Dictionary<string, int>();
+        = new System.Collections.Generic.Dictionary<string, int>(); 
 
     private SynergyItemRule GetActiveSynergyRule()
     {

--- a/Assets/00_WorkSpace/YSJ/Scripts/Player/PlayerRaceData.cs
+++ b/Assets/00_WorkSpace/YSJ/Scripts/Player/PlayerRaceData.cs
@@ -41,9 +41,6 @@ public class PlayerRaceData : MonoBehaviour, IPunInstantiateMagicCallback
     [SerializeField] private bool _isMovable = false;        // 이동 가능 여부
     [SerializeField] private bool _isItemUsable = false;     // 아이템 사용가능 여부
 
-    public Action OnBeforeRaceSetupAction;
-    public Action OnAfterRaceSetupAction;
-
     private bool _isEndRace = false;
     private int _currentTrackIndex = -1;
     private int _lap = 0;
@@ -260,9 +257,9 @@ public class PlayerRaceData : MonoBehaviour, IPunInstantiateMagicCallback
         this.PrintLog("GameManagerSetup 진행");
         if (_inGM != null && _useGM)
         {
-            // 로드
-            _inGM.OnRaceState_LoadPlayers -= OnPlayReady;
-            _inGM.OnRaceState_LoadPlayers += OnPlayReady;
+            // 카운트 다운
+            _inGM.OnRaceState_Countdown -= OnPlayReady;
+            _inGM.OnRaceState_Countdown += OnPlayReady;
 
             // 레이싱
             _inGM.OnRaceState_Racing -= OnPlayRaceEnter;
@@ -296,8 +293,6 @@ public class PlayerRaceData : MonoBehaviour, IPunInstantiateMagicCallback
         {
             if (_inGM != null && _lap >= _inGM.RaceEndLapCount)
             {
-                PhotonNetworkCustomProperties.LocalPlayerRaceFinishedSetting(PhotonNetwork.Time);
-
                 _isControlable = false;
                 _isMovable = false;
                 _isItemUsable = false;
@@ -544,7 +539,6 @@ public class PlayerRaceData : MonoBehaviour, IPunInstantiateMagicCallback
             $"_isSetups: {_isSetups}\n" +
             $"");
 
-        OnBeforeRaceSetupAction?.Invoke();
 
         // Setup(순서: (Kart > Character) > (Controller > Movement) > Sync > (Cam > AniCtrl > Synergy))
         // Visual
@@ -594,9 +588,9 @@ public class PlayerRaceData : MonoBehaviour, IPunInstantiateMagicCallback
 
         // 플레이어의 커스텀 프롬퍼티 생성 시점 > 매칭이 되었을 때
         // 룸데이터는 그 이전에 되어 있어야된다.
-        
+        var pm = PlayerManager.Instance;
+        pm?.SetPlayerCPRaceLoaded(IsSetups);
 
-        OnAfterRaceSetupAction?.Invoke();
         this.PrintLog("Delay Load Data 진행 완료");
     }
 

--- a/Assets/00_WorkSpace/YSJ/Scripts/Player/PlayerSpawner.cs
+++ b/Assets/00_WorkSpace/YSJ/Scripts/Player/PlayerSpawner.cs
@@ -31,7 +31,8 @@ public class PlayerSpawner : MonoBehaviour
     private int _reqKartID;
     private float _reqKartBaseSpeed;
 
-    private bool _isLoadBaseGO= false;
+    private bool _isLoadPlayer = false;
+    private bool _isLoadBaseGO = false;
     private bool _isReqCharacterID = false;
     private bool _isReqKartID = false;
     private bool _isReqKartBaseSpeed = false;
@@ -42,6 +43,7 @@ public class PlayerSpawner : MonoBehaviour
 
     private void Start()
     {
+        _isLoadPlayer = false;
         SetupInjecter();
         if (_isStartDirectSpawn)
         {
@@ -59,7 +61,8 @@ public class PlayerSpawner : MonoBehaviour
     // 외부 스폰 이관 시, 사용
     private void OnSpawnAction()
     {
-        StartCoroutine(CO_PlayerSpanwe());
+        if (!_isLoadPlayer)
+            StartCoroutine(CO_PlayerSpanwe());
     }
 
     // 플레이어 스폰 함수
@@ -326,6 +329,7 @@ public class PlayerSpawner : MonoBehaviour
 
         object[] instData = { _reqCharacterID, _reqKartID, _reqKartBaseSpeed};
         PhotonNetwork.Instantiate(_baseGO.name, Vector3.zero, Quaternion.identity, 0, instData);
+        _isLoadPlayer = true;
     }
 
     // onError

--- a/Assets/Resources/Visual_ItemBoxBody.prefab
+++ b/Assets/Resources/Visual_ItemBoxBody.prefab
@@ -1,0 +1,284 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &92855279926584434
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3968439531708733025}
+  - component: {fileID: 5353016363626720343}
+  - component: {fileID: 1834431170358087854}
+  - component: {fileID: 8243855011734941476}
+  - component: {fileID: 6621239787948839637}
+  m_Layer: 9
+  m_Name: Visual_ItemBoxBody
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 22
+  m_IsActive: 1
+--- !u!4 &3968439531708733025
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 92855279926584434}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4804433733113816869}
+  - {fileID: 5232912082639808022}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5353016363626720343
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 92855279926584434}
+  m_Mesh: {fileID: -1570809665986720783, guid: 58c3e6e01eabdb849af967f4af8540aa, type: 3}
+--- !u!23 &1834431170358087854
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 92855279926584434}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c7325ad57839af445a855851af6ff8dc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!205 &8243855011734941476
+LODGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 92855279926584434}
+  serializedVersion: 2
+  m_LocalReferencePoint: {x: 0.022418916, y: 0.49710757, z: -0.0039564073}
+  m_Size: 1.0359589
+  m_FadeMode: 1
+  m_AnimateCrossFading: 1
+  m_LastLODIsBillboard: 0
+  m_LODs:
+  - screenRelativeHeight: 0.24646835
+    fadeTransitionWidth: 0
+    renderers:
+    - renderer: {fileID: 1834431170358087854}
+  - screenRelativeHeight: 0.11990623
+    fadeTransitionWidth: 0
+    renderers:
+    - renderer: {fileID: 3442537227226640948}
+  - screenRelativeHeight: 0.022969956
+    fadeTransitionWidth: 0
+    renderers:
+    - renderer: {fileID: 7110524795125646664}
+  m_Enabled: 1
+--- !u!64 &6621239787948839637
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 92855279926584434}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -1570809665986720783, guid: 58c3e6e01eabdb849af967f4af8540aa, type: 3}
+--- !u!1 &5276510224540180822
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4804433733113816869}
+  - component: {fileID: 7831886582997481691}
+  - component: {fileID: 3442537227226640948}
+  m_Layer: 9
+  m_Name: Box_1_LOD0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 22
+  m_IsActive: 1
+--- !u!4 &4804433733113816869
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5276510224540180822}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0000000011920929, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3968439531708733025}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7831886582997481691
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5276510224540180822}
+  m_Mesh: {fileID: 1641547334348002049, guid: 58c3e6e01eabdb849af967f4af8540aa, type: 3}
+--- !u!23 &3442537227226640948
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5276510224540180822}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c7325ad57839af445a855851af6ff8dc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1 &6308551767483171964
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5232912082639808022}
+  - component: {fileID: 5366107357923033486}
+  - component: {fileID: 7110524795125646664}
+  m_Layer: 9
+  m_Name: Box_1_LOD1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 22
+  m_IsActive: 1
+--- !u!4 &5232912082639808022
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6308551767483171964}
+  m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0000000011920929, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3968439531708733025}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5366107357923033486
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6308551767483171964}
+  m_Mesh: {fileID: 3919242667707216154, guid: 58c3e6e01eabdb849af967f4af8540aa, type: 3}
+--- !u!23 &7110524795125646664
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6308551767483171964}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c7325ad57839af445a855851af6ff8dc, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0

--- a/Assets/Resources/Visual_ItemBoxBody.prefab.meta
+++ b/Assets/Resources/Visual_ItemBoxBody.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 10d7c8b4b994eaf4c9106b2cdb75c822
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 🧩 개요
- 카트 싱크 관련, 플레이어 자신의 현재 레이스 상황 업데이트 기능 추가  
- InGameManager에서 레이싱 CP 처리 시 이상 데이터로 인해 게임 시작과 동시에 종료되는 버그 수정  
- 스폰된 플레이어가 재소환되지 않도록 로직 수정  
- InGameManager에서 플레이어 자신 등록 정보를 외부에서 읽을 수 있도록 기능 추가  
- Player 레이싱 데이터 호출 타이밍(Action) 수정  
  - `OnRaceState_LoadPlayers` → `OnRaceState_Countdown = OnPlayReady`  

- 테스트용 아이템 박스 비주얼 처리 기능 추가  
- 테스트용 아이템 저장(지연 처리) 기능 추가  
- 테스트용 ItemBox Body 프리팹 복제 추가  

---

## 📁 변경 사항 체크리스트
- [x] C# 스크립트 추가/수정 (`InGameManager`, Player Sync 관련 코드 등)  
- [x] 프리팹 변경 (테스트용 ItemBox Body 추가)  
- [ ] 씬(.unity) 파일 변경  
- [ ] 애니메이션/사운드 리소스 변경  
- [ ] ScriptableObject 변경  
- [ ] 기타 리소스 또는 설정 변경  

---

## ✅ 확인 사항
- [x] Unity 에디터에서 정상 동작 확인  
- [x] 레이스 상황 업데이트 정상 동작 확인  
- [x] 플레이어 스폰 및 중복 소환 방지 확인  
- [x] InGameManager 플레이어 정보 외부 접근 정상 동작 확인  
- [ ] 변경된 파일이 Git LFS 대상인지 확인 (필요 시)  
- [x] 최신 dev 브랜치와 병합 완료  

---

## 🧪 테스트 내역
- [x] 카트 싱크 및 레이스 상황 업데이트 정상 작동 확인  
- [x] InGameManager CP 처리 버그 수정 후 게임 진행 정상 확인  
- [x] 플레이어 스폰 후 재소환 방지 정상 작동 확인  
- [x] 테스트 아이템 박스 비주얼 처리 및 저장 기능 실행 확인  
- [ ] 멀티플레이 환경에서 추가 테스트 필요  

---

## 📝 기타
- InGameManager 개선으로 레이싱 진행 사이클 안정화  
- 아이템 박스 관련 테스트 기능은 추후 정식 아이템 시스템으로 확장 가능 