### PR TITLE
fix: 동일한 메서드가 2개 있던 에러 수정

### DIFF
--- a/Assets/00_WorkSpace/MSG/Scripts/Managers/FirebaseManager.cs
+++ b/Assets/00_WorkSpace/MSG/Scripts/Managers/FirebaseManager.cs
@@ -71,11 +71,6 @@ namespace MSG
             this.PrintLog("파이어 베이스 OnDestroy() 실행");
         }
 
-        private void OnDestroy()
-        {
-            Debug.Log("파괴됨");
-        }
-
         private void Start()
         {
             this.PrintLog("파이어 베이스 Start() 진행");

--- a/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20002.asset
+++ b/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20002.asset
@@ -14,15 +14,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterId: 20002
   characterName: "\uC810\uBD84\uC774"
-  characterPrefab: {fileID: 4239981488029269299, guid: 834c26b85244f0a499ba417d481df5ef,
-    type: 3}
-  characterSprite: {fileID: 21300000, guid: f591dc3330b2b414eb6464e776ffacc5, type: 3}
+  characterPrefab: {fileID: 0}
+  characterSprite: {fileID: 0}
   currencyType: {fileID: 0}
   characterInfo: "\uC790\uC2E0\uC758 \uC790\uB9AC\uB97C \uB418\uCC3E\uACE0 \uC2F6\uC5B4\uD558\uB294
     \uD1A0\uB07C"
   SynergyKartID: 10002
-  relationCharacterId: -1
-  dialogId: -1
+  relationCharacterId: 20013
+  dialogId: 21006
   useAddr: 1
   characterPrefabRef:
     m_AssetGUID: 834c26b85244f0a499ba417d481df5ef

--- a/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20003.asset
+++ b/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20003.asset
@@ -14,14 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterId: 20003
   characterName: "\uC18C\uD3EC"
-  characterPrefab: {fileID: 2090828822177639507, guid: d169d16d267a65849bec71e24dcc6617,
-    type: 3}
-  characterSprite: {fileID: 21300000, guid: e58d009362b32734d8a4ade12bd84a01, type: 3}
+  characterPrefab: {fileID: 0}
+  characterSprite: {fileID: 0}
   currencyType: {fileID: 0}
   characterInfo: "\uC0C1\uC790\uB294 \uB0B4\uAC70\uC57C"
   SynergyKartID: 10003
-  relationCharacterId: -1
-  dialogId: -1
+  relationCharacterId: 20005
+  dialogId: 21003
   useAddr: 1
   characterPrefabRef:
     m_AssetGUID: d169d16d267a65849bec71e24dcc6617

--- a/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20004.asset
+++ b/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20004.asset
@@ -14,14 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterId: 20004
   characterName: "\uACF0\uACF0"
-  characterPrefab: {fileID: 4600803693058095967, guid: 7add4971919c67b408a29c006276aa63,
-    type: 3}
-  characterSprite: {fileID: 21300000, guid: ef007859432c7f64bacc6ed4249ac82f, type: 3}
+  characterPrefab: {fileID: 0}
+  characterSprite: {fileID: 0}
   currencyType: {fileID: 0}
   characterInfo: "\uC5EC\uB984 \uC7A0\uC744 \uC790\uB294 \uB3D9\uADF8\uB780 \uACF0"
   SynergyKartID: 10004
-  relationCharacterId: -1
-  dialogId: -1
+  relationCharacterId: 20001
+  dialogId: 21001
   useAddr: 1
   characterPrefabRef:
     m_AssetGUID: 7add4971919c67b408a29c006276aa63

--- a/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20005.asset
+++ b/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20005.asset
@@ -14,14 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterId: 20005
   characterName: "\uACE0\uB4F1\uC5B4"
-  characterPrefab: {fileID: 9140679650219347157, guid: 717274adc3aa0e649a4abff96c56c667,
-    type: 3}
-  characterSprite: {fileID: 21300000, guid: 52dcd754192c79b47ae18c36331c08da, type: 3}
+  characterPrefab: {fileID: 0}
+  characterSprite: {fileID: 0}
   currencyType: {fileID: 0}
   characterInfo: "\uC2E0\uC120\uD55C \uB4F1 \uD478\uB978 \uC720\uB2C8\uBAA8"
   SynergyKartID: 10005
-  relationCharacterId: -1
-  dialogId: -1
+  relationCharacterId: 20003
+  dialogId: 21004
   useAddr: 1
   characterPrefabRef:
     m_AssetGUID: 717274adc3aa0e649a4abff96c56c667

--- a/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20006.asset
+++ b/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20006.asset
@@ -14,14 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterId: 20006
   characterName: "\uCFE0"
-  characterPrefab: {fileID: 237807714108120016, guid: ecb6c77abc6720042a9f6ccd7d8ca431,
-    type: 3}
-  characterSprite: {fileID: 21300000, guid: 34eeb5c8c75b1644cab366b97c899c7c, type: 3}
+  characterPrefab: {fileID: 0}
+  characterSprite: {fileID: 0}
   currencyType: {fileID: 0}
   characterInfo: "\uB77C\uCFE4 \uC544\uB2CC\uB370"
   SynergyKartID: 10006
-  relationCharacterId: -1
-  dialogId: -1
+  relationCharacterId: 20008
+  dialogId: 21008
   useAddr: 1
   characterPrefabRef:
     m_AssetGUID: ecb6c77abc6720042a9f6ccd7d8ca431

--- a/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20007.asset
+++ b/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20007.asset
@@ -14,14 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterId: 20007
   characterName: "\uB460\uB460"
-  characterPrefab: {fileID: 4295636587615923878, guid: 57de376fda9433f4a90d660f8399a687,
-    type: 3}
-  characterSprite: {fileID: 21300000, guid: d63fbd7e2ab1c9b4c9a716db8f129885, type: 3}
+  characterPrefab: {fileID: 0}
+  characterSprite: {fileID: 0}
   currencyType: {fileID: 0}
   characterInfo: "\uBC1D\uAC8C \uBE5B\uB098\uB294 \uAC83\uB4E4\uC744 \uBAA8\uC544\uC694"
   SynergyKartID: 10007
-  relationCharacterId: -1
-  dialogId: -1
+  relationCharacterId: 20009
+  dialogId: 21010
   useAddr: 1
   characterPrefabRef:
     m_AssetGUID: 57de376fda9433f4a90d660f8399a687

--- a/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20008.asset
+++ b/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20008.asset
@@ -14,14 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterId: 20008
   characterName: "\uC544\uC6B0\uAD6C\uC2A4\uD22C\uC2A4"
-  characterPrefab: {fileID: 805713175675155010, guid: 561fb7f1436b6974b948d1172da9bdea,
-    type: 3}
-  characterSprite: {fileID: 21300000, guid: 906822dda85bcd44182f0742237caa4c, type: 3}
+  characterPrefab: {fileID: 0}
+  characterSprite: {fileID: 0}
   currencyType: {fileID: 0}
   characterInfo: "\uD63C\uC790\uC11C\uB3C4 \uB0A0 \uC218 \uC788\uB2E4\uACE0"
   SynergyKartID: 10008
-  relationCharacterId: -1
-  dialogId: -1
+  relationCharacterId: 20006
+  dialogId: 21007
   useAddr: 1
   characterPrefabRef:
     m_AssetGUID: 561fb7f1436b6974b948d1172da9bdea

--- a/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20009.asset
+++ b/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20009.asset
@@ -14,14 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterId: 20009
   characterName: "\uBA38\uD540"
-  characterPrefab: {fileID: 6534607643317645777, guid: e7e6790557cfbcd4aa505fc214707394,
-    type: 3}
-  characterSprite: {fileID: 21300000, guid: d0a1c3edbec360143add23da8192a6b4, type: 3}
+  characterPrefab: {fileID: 0}
+  characterSprite: {fileID: 0}
   currencyType: {fileID: 0}
   characterInfo: "\uC9D1\uC740 \uBABB \uC9C0\uCF1C"
   SynergyKartID: 10009
-  relationCharacterId: -1
-  dialogId: -1
+  relationCharacterId: 20007
+  dialogId: 21009
   useAddr: 1
   characterPrefabRef:
     m_AssetGUID: e7e6790557cfbcd4aa505fc214707394

--- a/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20010.asset
+++ b/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20010.asset
@@ -14,14 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterId: 20010
   characterName: "\uB9C8\uD2F8\uB2E4"
-  characterPrefab: {fileID: 5481292536347481171, guid: 7298211242ffed7419e94d6fde2c0656,
-    type: 3}
-  characterSprite: {fileID: 21300000, guid: 52822009cdd7ec74a919d5831a06f67c, type: 3}
+  characterPrefab: {fileID: 0}
+  characterSprite: {fileID: 0}
   currencyType: {fileID: 0}
   characterInfo: "\uCF54 \uB204\uB974\uC9C0 \uB9C8"
   SynergyKartID: 10010
-  relationCharacterId: -1
-  dialogId: -1
+  relationCharacterId: 20012
+  dialogId: 21012
   useAddr: 1
   characterPrefabRef:
     m_AssetGUID: 7298211242ffed7419e94d6fde2c0656

--- a/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20012.asset
+++ b/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20012.asset
@@ -14,14 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterId: 20012
   characterName: "\uC54C"
-  characterPrefab: {fileID: 9012688025184599837, guid: 8718455dd8be0c64fb5f13b2f991fa5d,
-    type: 3}
-  characterSprite: {fileID: 21300000, guid: 6b72a7423a78a73468e58e1cd7f54e18, type: 3}
+  characterPrefab: {fileID: 0}
+  characterSprite: {fileID: 0}
   currencyType: {fileID: 0}
   characterInfo: "\uB099\uD0C0 \uC2EB\uC5B4"
   SynergyKartID: 10012
-  relationCharacterId: -1
-  dialogId: -1
+  relationCharacterId: 20010
+  dialogId: 21011
   useAddr: 1
   characterPrefabRef:
     m_AssetGUID: 8718455dd8be0c64fb5f13b2f991fa5d

--- a/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20013.asset
+++ b/Assets/Resources/SO/Unimo/Character/UnimoCharacterSO_20013.asset
@@ -14,14 +14,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   characterId: 20013
   characterName: "\uD504\uB9AC\uBAA8"
-  characterPrefab: {fileID: 8519055103165763922, guid: 908c4f8516722c345942832e4a2cfce1,
-    type: 3}
-  characterSprite: {fileID: 21300000, guid: 02cd3a0ed43e940498bc0d9577652845, type: 3}
+  characterPrefab: {fileID: 0}
+  characterSprite: {fileID: 0}
   currencyType: {fileID: 0}
   characterInfo: "\uB178\uB294\uAC8C \uC81C\uC77C \uC88B\uC544"
   SynergyKartID: 10013
-  relationCharacterId: -1
-  dialogId: -1
+  relationCharacterId: 20002
+  dialogId: 21005
   useAddr: 1
   characterPrefabRef:
     m_AssetGUID: 908c4f8516722c345942832e4a2cfce1


### PR DESCRIPTION
## 🧩 개요
-  동일한 메서드가 2개 있던 에러 수정
- 유니모 SO에 관계 캐릭터 및 대사 id 추가

## 📁 변경 사항 체크리스트

- [x] C# 스크립트 추가/수정
- [ ] 프리팹 변경
- [ ] 씬(.unity) 파일 변경
- [ ] 애니메이션/사운드 리소스 변경
- [x] ScriptableObject 변경
- [ ] 기타 리소스 또는 설정 변경

## ✅ 확인 사항

- [ ] Unity 에디터에서 정상 동작 확인
- [ ] 관련 기능 플레이 테스트 완료
- [ ] 에러/경고 없음
- [ ] 변경된 파일이 Git LFS 대상인지 확인 (필요시)
- [ ] 충돌 방지를 위해 최신 develop/main 브랜치에서 작업

## 🧪 테스트 내역

- [ ] 새 기능 직접 실행 확인
- [ ] 씬 변경 시, 기존 오브젝트와 충돌 없음
- [ ] 멀티플레이/네트워크 관련 기능 확인 (해당 시)
- [ ] (선택) 커스텀 유닛/에디터 테스트 포함

## 📝 기타
